### PR TITLE
Generate Packages Natively with Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,43 @@ name = "cargo-deb"
 version = "0.0.1"
 dependencies = [
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-lzma 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.6 (git+https://github.com/mmstick/tar-rs)",
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zopfli 0.3.0 (git+https://github.com/carols10cents/zopfli)",
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
+name = "adler32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crc"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "filetime"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -23,9 +47,33 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rust-lzma"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tar"
+version = "0.4.6"
+source = "git+https://github.com/mmstick/tar-rs#96ff38490a98b0ebe72d64b208d52d66f24bd611"
+dependencies = [
+ "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xattr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "toml"
@@ -36,21 +84,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "walkdir"
-version = "0.1.5"
+name = "xattr"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "zopfli"
+version = "0.3.0"
+source = "git+https://github.com/carols10cents/zopfli#6642b3e470e343425ccc66d29507c6c55e45aa8c"
+dependencies = [
+ "adler32 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license_file = ["LICENSE", "4"]
 extended_description = """\
 A simple subcommand for the Cargo package manager for \
 building Debian packages from Rust projects."""
-depends = "libc6"
+depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
@@ -26,4 +26,6 @@ assets = [
 rustc-serialize = "0.3.19"
 toml = "0.1.28"
 libc = "0.2.12"
-walkdir = "0.1.5"
+tar = { git = "https://github.com/mmstick/tar-rs" }
+rust-lzma = "0.2.1"
+zopfli = { git = "https://github.com/carols10cents/zopfli" }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
+# How It Works
 This cargo subcommand will largely automate the process of building a Debian package. In order to get a Rust project build with `cargo deb`, you must add a [packages.metadata.deb] table to your Cargo.toml file. You must also ensure that you have filled out the minimal package information, particularly the `description` and `repository` values.
 
-### Example [package.metadata.deb]
+This subcommand will read the files into tar archives and assign their permissions in memory, then it will compress the
+control.tar archive in memory with the Rust implementation of the Zopfli library to transform it into a
+control.tar.gz file in memory. It will similarly create a data.tar archive in memory and subsequently compress it with
+the lzma system library, at least until a native Rust implementation is offered. Finally, it will wrap the files up
+using the ar format and save the resulting file to disk in target/debian.
+
+# Available Keys
 The required keys are `maintainer`, `copyright`, `license_file`, `depends`, `extended_description`, `section`, `priority`, and `assets`.
 
 The `license_file` parameter contains the location of the license file followed by the number of lines to skip (because Debian uses it's own copyright format).
+
+The `depends` parameter contains the runtime dependencies that are required by the package. If you would like to have
+dependencies automatically generated, you can add `$auto` to this line to have `$auto` replaced with a list of
+dependencies that were found when using ldd. The automatic dependency resolution will not work on non-Debian systems.
 
 The `assets` are a list of files that will be installed into the system.
 - The first argument of each asset is the location of that asset in the Rust project.
 - The second argument is where the file will be copied.
     - If is argument ends with **/** it will be inferred that the target is the directory where the file will be copied.
     - Otherwise, it will be inferred that the source argument will be renamed when copied.
-- The third argument is the permissions to assign that file via chmod.
+- The third argument is the permissions to assign that file.
 
-### Running `cargo deb`
+# Running `cargo deb`
 Upon running `cargo deb` from the base directory of your Rust project, a Debian package will be saved in the same
 directory. If you would like to handle the build process yourself, you can use `cargo deb --no-build` so that the
 `cargo-deb` command will not attempt to rebuild your project.
@@ -27,7 +38,7 @@ license_file = ["LICENSE", "4"]
 extended_description = """\
 A simple subcommand for the Cargo package manager for \
 building Debian packages from Rust projects."""
-depends = "libc6"
+depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
@@ -43,7 +54,7 @@ assets = [
 maintainer = "Michael Aaron Murphy <mmstickman@gmail.com>"
 copyright = "2015-2016, Michael Aaron Murphy <mmstickman@gmail.com>"
 license_file = ["LICENSE", "3"]
-depends = "libc6, libgtk-3-0 (>= 3.16)"
+depends = "$auto"
 extended_description = """\
 Written safely in Rust, this systemd manager provides a simple GTK3 GUI interface \
 that allows you to enable/disable/start/stop services, monitor service logs, and \

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::io::Write;
+use zopfli;
+use lzma;
+use try::{failed, Try};
+
+/// Compresses data using the [native Rust implementation of Zopfli](https://github.com/carols10cents/zopfli).
+pub fn gz(data: Vec<u8>, path: &str) {
+    fs::OpenOptions::new().create(true).write(true).truncate(true).open(path).ok()
+        .map_or_else(|| failed(format!("cargo-deb: unable to create {}", path)), |mut file| {
+            let mut compressed: Vec<u8> = Vec::new();
+            let options = zopfli::Options::default();
+            let format = zopfli::Format::Gzip;
+            zopfli::compress(&options, &format, &data, &mut compressed)
+                .try("cargo-deb: error with zopfli compression");
+            file.write(&compressed[..])
+                .try(&format!("cargo-deb: unable to write to {}", path));
+        });
+}
+
+/// Compresses data using the system xz library
+pub fn xz(data: Vec<u8>, path: &str) {
+    fs::OpenOptions::new().create(true).write(true).truncate(true).open(path).ok()
+        .map_or_else(|| failed(format!("cargo-deb: unable to create {}", path)), |mut file| {
+            let data = lzma::compress(&data, 9).try("cargo-deb: failed to compress archive with xz");
+            file.write(&data[..]).try(&format!("cargo-deb: unable to write to {}", path));
+        });
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,118 @@
+use std::io::{self, Write};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use config::Config;
+use try::{failed, Try};
+use tar::Builder as TarBuilder;
+use tar::Header as TarHeader;
+use tar::EntryType;
+
+const CHMOD_FILE:       u32 = 420;
+const CHMOD_BIN_OR_DIR: u32 = 493;
+
+/// Generates the uncompressed control.tar archive
+pub fn generate_archive(archive: &mut TarBuilder<Vec<u8>>, options: &Config, time: &u64) {
+    initialize_control(archive, time);
+    generate_md5sums(archive, options, time);
+    generate_control(archive, options, time);
+    generate_conf_files(archive, options.conf_files.as_ref(), time);
+}
+
+/// Creates the initial hidden directory where all the files are stored.
+fn initialize_control(archive: &mut TarBuilder<Vec<u8>>, time: &u64) {
+    let mut header = TarHeader::new_gnu();
+    header.set_mtime(*time);
+    header.set_size(0);
+    header.set_mode(CHMOD_BIN_OR_DIR);
+    header.set_path(".").unwrap();
+    header.set_entry_type(EntryType::Directory);
+    header.set_cksum();
+    archive.append(&header, &mut io::empty()).unwrap();
+}
+
+/// Creates the md5sums file which contains a list of all contained files and the md5sums of each.
+fn generate_md5sums(archive: &mut TarBuilder<Vec<u8>>, options: &Config, time: &u64) {
+    let mut md5sums: Vec<u8> = Vec::new();
+    for asset in &options.assets {
+        let origin = asset.get(0).try("cargo-deb: unable to get asset's path");
+        let mut target: String = asset.get(1).try("cargo-deb: unable to get asset's target").clone();
+        if target.chars().next().unwrap() == '/' { target.remove(0); }
+        let target_is_dir = target.chars().last().unwrap() == '/';
+        Command::new("md5sum").arg(&origin).output().ok().map_or_else(|| failed("cargo-deb: could not get output of md5sum"), |x| {
+            let mut hash = x.stdout.iter().take_while(|&&x| x != b' ').cloned().collect::<Vec<u8>>();
+            hash.write(b"  ").unwrap();
+            if target_is_dir {
+                write!(&mut hash, "{}{}", target, Path::new(origin).file_name().unwrap().to_str().unwrap()).unwrap();
+            } else {
+                hash.write(asset.get(1).unwrap().as_bytes()).unwrap();
+            }
+            hash.write(&[b'\n']).unwrap();
+            md5sums.append(&mut hash);
+        });
+    }
+    // Obtain the md5sum of the copyright file
+    Command::new("md5sum").arg("target/debian/copyright").output().ok().map_or_else(|| failed("cargo-deb: could not get output of md5sum"), |x| {
+        let mut hash = x.stdout.iter().take_while(|&&x| x != b' ').cloned().collect::<Vec<u8>>();
+        hash.write(b"  ").unwrap();
+        let path = String::from("usr/share/doc/") + &options.name + "/copyright";
+        hash.write(path.as_bytes()).unwrap();
+        md5sums.append(&mut hash);
+        md5sums.push(10);
+    });
+    // We can now exterminate the copyright file as it has outlived it's usefulness.
+    fs::remove_file("target/debian/copyright").try("cargo-deb: copyright file doesn't exist.");
+    // Write the data to the archive
+    let mut header = TarHeader::new_gnu();
+    header.set_mtime(*time);
+    header.set_path("./md5sums").unwrap();
+    header.set_size(md5sums.len() as u64);
+    header.set_mode(CHMOD_FILE);
+    header.set_cksum();
+    archive.append(&header, md5sums.as_slice()).try("cargo-deb: unable to append md5sums");
+}
+
+/// Generates the control file that obtains all the important information about the package.
+fn generate_control(archive: &mut TarBuilder<Vec<u8>>, options: &Config, time: &u64) {
+    // Create and return the handle to the control file with write access.
+    let mut control: Vec<u8> = Vec::new();
+    // Write all of the lines required by the control file.
+    write!(&mut control, "Package: {}\n", options.name).unwrap();
+    write!(&mut control, "Version: {}\n", options.version).unwrap();
+    write!(&mut control, "Section:{}\n", options.section).unwrap();
+    write!(&mut control, "Priority: {}\n", options.priority).unwrap();
+    control.write(b"Standards-Version: 3.9.4\n").unwrap();
+    write!(&mut control, "Maintainer: {}\n", options.maintainer).unwrap();
+    write!(&mut control, "Architecture: {}\n", options.architecture).unwrap();
+    write!(&mut control, "Depends: {}\n", options.depends).unwrap();
+    write!(&mut control, "Description: {}\n", options.description).unwrap();
+    // Write each of the lines that were collected from the extended_description to the file.
+    for line in &options.extended_description {
+        write!(&mut control, " {}\n", line).unwrap();
+    }
+    control.push(10);
+    // Add the control file to the tar archive.
+    let mut header = TarHeader::new_gnu();
+    header.set_mtime(*time);
+    header.set_path("./control").unwrap();
+    header.set_size(control.len() as u64);
+    header.set_mode(CHMOD_FILE);
+    header.set_cksum();
+    archive.append(&header, control.as_slice()).try("cargo-deb: unable to append control");
+}
+
+/// If configuration files are required, the conffiles file will be created.
+fn generate_conf_files(archive: &mut TarBuilder<Vec<u8>>, conf_file: Option<&String>, time: &u64) {
+    if let Some(files) = conf_file {
+        let mut data: Vec<u8> = Vec::new();
+        data.write(files.clone().as_bytes()).unwrap();
+        data.push(10);
+        let mut header = TarHeader::new_gnu();
+        header.set_mtime(*time);
+        header.set_path("./conffiles").unwrap();
+        header.set_size(data.len() as u64);
+        header.set_mode(CHMOD_FILE);
+        header.set_cksum();
+        archive.append(&header, data.as_slice()).try("cargo-deb: unable to append conffiles");
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{PathBuf, Path};
+use std::os::unix::fs::OpenOptionsExt;
+use tar::Header as TarHeader;
+use tar::Builder as TarBuilder;
+use tar::EntryType;
+
+use config::Config;
+use try::{failed, Try};
+
+
+const CHMOD_FILE:       u32 = 420;
+const CHMOD_BIN_OR_DIR: u32 = 493;
+
+/// Generates the uncompressed control.tar archive
+pub fn generate_archive(archive: &mut TarBuilder<Vec<u8>>, options: &Config, time: &u64) {
+    copy_files(archive, options, time);
+    generate_copyright(archive, options, time);
+}
+
+/// Generates the copyright file from the license file and adds that to the tar archive.
+fn generate_copyright(archive: &mut TarBuilder<Vec<u8>>, options: &Config, time: &u64) {
+    let mut copyright: Vec<u8> = Vec::new();
+    write!(&mut copyright, "Upstream Name: {}\n", options.name).unwrap();
+    write!(&mut copyright, "Source: {}\n", options.repository).unwrap();
+    write!(&mut copyright, "Copyright: {}\n", options.copyright).unwrap();
+    write!(&mut copyright, "License: {}\n", options.license).unwrap();
+    options.license_file.get(0)
+        // Fail if the path cannot be found and report that the license file argument is missing.
+        .map_or_else(|| failed("cargo-deb: missing license file argument"), |path| {
+            // Now we need to obtain the amount of lines to skip at the top of the file.
+            let lines_to_skip = options.license_file.get(1)
+                // If no argument is given, or if the argument is not a number, return 0.
+                .map_or(0, |x| x.parse::<usize>().unwrap_or(0));
+            // Now we need to attempt to open the file.
+            let mut file = fs::File::open(path).try("cargo-deb: license file could not be opened");
+            // The capacity of the file can be obtained from the metadata.
+            let capacity = file.metadata().map(|x| x.len()).unwrap_or(0) as usize;
+            // We are going to store the contents of the license file in a single string with the size of file.
+            let mut license_string = String::with_capacity(capacity);
+            // Attempt to read the contents of the license file into the license string.
+            file.read_to_string(&mut license_string).try("cargo-deb: error reading license file");
+            // Skip the first `A` number of lines and then iterate each line after that.
+            for line in license_string.lines().skip(lines_to_skip) {
+                // If the line is empty, write a dot, else write the line.
+                if line.is_empty() {
+                    copyright.write(b".\n").unwrap();
+                } else {
+                    write!(&mut copyright, "{}\n", line.trim()).unwrap();
+                }
+            }
+        });
+
+    // Write a copy to the disk for the sake of obtaining a md5sum for the control archive.
+    let mut file = fs::OpenOptions::new().create(true).write(true).truncate(true).mode(CHMOD_FILE)
+        .open("target/debian/copyright").unwrap_or_else(|err| {
+            failed(format!("cargo-deb: unable to open copyright file for writing: {}", err.to_string()));
+        });
+    file.write_all(copyright.as_slice()).try("cargo-deb: unable to write copyright file to disk");
+
+    // Now add a copy to the archive
+    let mut header = TarHeader::new_gnu();
+    header.set_mtime(*time);
+    header.set_path(&PathBuf::from("./usr/share/doc/").join(&options.name).join("copyright")).unwrap();
+    header.set_size(copyright.len() as u64);
+    header.set_mode(CHMOD_FILE);
+    header.set_cksum();
+    archive.append(&header, copyright.as_slice()).try("cargo-deb: unable to append copyright");
+}
+
+/// Copies all the files to be packaged into the tar archive.
+fn copy_files(archive: &mut TarBuilder<Vec<u8>>, options: &Config, time: &u64) {
+    let mut added_directories: Vec<String> = Vec::new();
+    for asset in &options.assets {
+        // Collect the source and target paths
+        let origin = asset.get(0).try("cargo-deb: unable to get asset's path");
+        let mut target = String::from("./") + asset.get(1).try("cargo-deb: unable to get asset's target");
+        let chmod = asset.get(2).map(|x| u32::from_str_radix(x, 8).unwrap())
+            .try("cargo-deb: unable to get chmod argument");
+        if target.chars().next().unwrap() == '/' { target.remove(0); }
+        if target.chars().last().unwrap() == '/' {
+            target.push_str(Path::new(origin).file_name().unwrap().to_str().unwrap());
+        }
+
+        // Collect a list of directories
+        let directories = target.char_indices()
+            .filter(|&(_, character)| character == '/')
+            .map(|(id, _)| String::from(&target[0..id])).collect::<Vec<String>>();
+
+        // Create all of the intermediary directories in the archive before adding the file
+        for directory in directories {
+            if !added_directories.iter().any(|x| x == &directory) {
+                added_directories.push(directory.clone());
+                let mut header = TarHeader::new_gnu();
+                header.set_mtime(*time);
+                header.set_size(0);
+                header.set_mode(CHMOD_BIN_OR_DIR);
+                header.set_path(&directory).unwrap();
+                header.set_entry_type(EntryType::Directory);
+                header.set_cksum();
+                archive.append(&header, &mut io::empty()).unwrap();
+            }
+        }
+
+        // Add the file to the archive
+        let mut file = fs::File::open(&origin).try("cargo-deb: unable to open file");
+        let capacity = file.metadata().ok().map_or(0, |x| x.len()) as usize;
+        let mut out_data: Vec<u8> = Vec::with_capacity(capacity);
+        file.read_to_end(&mut out_data).try("cargo-deb: unable to read asset's data");
+        let mut header = TarHeader::new_gnu();
+        header.set_mtime(*time);
+        header.set_path(&target).unwrap();
+        header.set_mode(chmod);
+        header.set_size(capacity as u64);
+        header.set_cksum();
+        archive.append(&header, out_data.as_slice()).try("cargo-deb: unable to write data to archive.");
+    }
+}

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,0 +1,67 @@
+use std::process::{exit, Command};
+
+struct Dependency {
+    name:    String,
+    version: String
+}
+
+/// Resolves the dependencies based on the output of ldd on the binary.
+pub fn resolve<S: AsRef<str>>(path: S) -> String {
+    let path = path.as_ref();
+    let output = Command::new("ldd").arg(path).output().unwrap().stdout;
+    let string = unsafe { String::from_utf8_unchecked(output) };
+    let dependencies = collect_dependencies(&string);
+    let mut output = String::new();
+    for depend in &dependencies {
+        output.push_str(&depend.name);
+        output.push_str(" (>= ");
+        output.push_str(&depend.version);
+        output.push_str("), ");
+    }
+    let capacity = output.chars().count();
+    output.truncate(capacity-2);
+    output
+}
+
+/// Collects a list of dependencies from the output of ldd
+fn collect_dependencies(ldd: &str) -> Vec<Dependency> {
+    let mut dependencies: Vec<Dependency> = Vec::new();
+    for line in ldd.lines() {
+        let mut words = line.split_whitespace();
+        let word = words.nth(2);
+        if word.is_none() { continue }
+        let path = word.unwrap();
+        if path.chars().next().unwrap() == '/' {
+            let package = get_package_name(path);
+            if dependencies.iter().any(|x| &x.name == &package) { continue }
+            match get_version(&package) {
+                Some(version) => dependencies.push(Dependency{name: package, version: version}),
+                None => continue
+            }
+        }
+    }
+    dependencies
+}
+
+/// Obtains the name of the package that belongs to the file that ldd returned
+fn get_package_name(path: &str) -> String {
+    let package = Command::new("dpkg").arg("-S").arg(path).output().unwrap().stdout.iter()
+        .take_while(|&&x| x != b':').cloned().collect::<Vec<u8>>();
+    unsafe { String::from_utf8_unchecked(package) }
+}
+
+/// Uses apt-cache policy to determine the version of the package that this project was built against.
+fn get_version(package: &str) -> Option<String> {
+    let output = Command::new("apt-cache").arg("policy").arg(&package)
+        .output().unwrap().stdout;
+    let string = unsafe { String::from_utf8_unchecked(output) };
+    string.lines().nth(1).map(|installed_line| {
+        let installed = installed_line.split_whitespace().nth(1).unwrap();
+        if installed == "(none)" {
+            println!("{} is not installed", &package);
+            exit(1);
+        } else {
+            installed.chars().take_while(|&x| x != '-').collect()
+        }
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,207 +1,95 @@
 extern crate libc;
 extern crate rustc_serialize;
 extern crate toml;
-extern crate walkdir;
+extern crate tar;
+extern crate lzma;
+extern crate zopfli;
 
+mod compress;
 mod config;
+mod control;
+mod data;
+mod dependencies;
 mod try;
 mod wordsplit;
 
-use std::ffi::CString;
+use std::env;
 use std::fs;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::io::Write;
 use std::process::Command;
+use std::time;
+use std::os::unix::fs::OpenOptionsExt;
 
 use config::Config;
 use try::{failed, Try};
-use walkdir::WalkDir;
+use tar::Builder as TarBuilder;
 
-enum CopyError {
-    CopyFailed,
-    ChmodMissing,
-    ChmodInvalid(String),
-    ChmodError(u32)
-}
+const CHMOD_FILE: u32 = 420;
 
 fn main() {
+    remove_leftover_files();
+    if !std::env::args().any(|x| x.as_str() == "--no-build") {
+        cargo_build();
+    }
     let options = Config::new();
-    if !std::env::args().any(|x| x.as_str() == "--no-build") { cargo_build(options.name.as_str()); }
-    copy_files(&options.assets);
-    generate_control(&options);
-    generate_copyright(&options);
-    set_directory_permissions();
+    strip_binary(options.name.as_str());
+
+    // Obtain current time
+    let system_time = time::SystemTime::now().duration_since(time::UNIX_EPOCH)
+        .try("cargo-deb: unable to get system time").as_secs();
+
+    // Initailize the data archive
+    let mut data_archive = TarBuilder::new(Vec::new());
+    data::generate_archive(&mut data_archive, &options, &system_time);
+
+    // Initialize the control archive
+    let mut control_archive = TarBuilder::new(Vec::new());
+    control::generate_archive(&mut control_archive, &options, &system_time);
+
+    // Compress the archives
+    data_archive.into_inner()
+        .map(|tar| compress::xz(tar, "target/debian/data.tar.xz"))
+        .try("cargo-deb: failed to tar contents");
+    control_archive.into_inner()
+        .map(|tar| compress::gz(tar, "target/debian/control.tar.gz"))
+        .try("cargo-deb: failed to tar contents");
+    generate_debian_binary_file();
     generate_deb(&options);
 }
 
-// Rust creates directories with 775 by default. This changes them to the correct permissions, 755.
-fn set_directory_permissions() {
-    for entry in WalkDir::new("target/debian").into_iter().map(|entry| entry.unwrap()) {
-        if entry.metadata().unwrap().is_dir() {
-            let c_string = CString::new(entry.path().to_str().unwrap()).unwrap();
-            let status = unsafe { libc::chmod(c_string.as_ptr(), u32::from_str_radix("755", 8).unwrap()) };
-            if status < 0 { failed("cargo-deb: chmod error occurred changing directory permissions"); }
-        }
-    }
+/// Uses the ar program to create the final Debian package, at least until a native ar implementation is implemented.
+fn generate_deb(config: &Config) {
+    env::set_current_dir("target/debian").unwrap();
+    let outpath = config.name.clone() + "_" + &config.version + "_" +
+        &config.architecture + ".deb";
+    let _ = fs::remove_file(&outpath); // Remove it if it exists
+    Command::new("ar").arg("r").arg(outpath).arg("debian-binary").arg("control.tar.gz").arg("data.tar.xz").status()
+        .try("cargo-deb: unable to create debian archive");
+
 }
 
-/// Attempts to generate a Debian package
-fn generate_deb(options: &Config) {
-    // fakeroot dpkg-deb --build debian "package-name_version_architecture.deb"
-    let package_name = options.name.clone() + "_" + options.version.as_str() + "_" + options.architecture.as_str() + ".deb";
-    Command::new("fakeroot").arg("dpkg-deb").arg("--build").arg("target/debian").arg(&package_name).status().
-        try("cargo-deb: failed to generate Debian package");
-}
-
-/// Generates the debian/control file needed by the package.
-fn generate_control(options: &Config) {
-    // Create and return the handle to the control file with write access.
-    let mut control = fs::OpenOptions::new().create(true).write(true).truncate(true).open("target/debian/DEBIAN/control")
-        .try("cargo-deb: could not create target/debian/DEBIAN/control");
-    // Write all of the lines required by the control file.
-    write!(&mut control, "Package: {}\n", options.name).unwrap();
-    write!(&mut control, "Version: {}\n", options.version).unwrap();
-    write!(&mut control, "Section: {}\n", options.section).unwrap();
-    write!(&mut control, "Priority: {}\n", options.priority).unwrap();
-    control.write(b"Standards-Version: 3.9.4\n").unwrap();
-    write!(&mut control, "Maintainer: {}\n", options.maintainer).unwrap();
-    write!(&mut control, "Architecture: {}\n", options.architecture).unwrap();
-    write!(&mut control, "Depends: {}\n", options.depends).unwrap();
-    write!(&mut control, "Description: {}\n", options.description).unwrap();
-    // Write each of the lines that were collected from the extended_description to the file.
-    for line in &options.extended_description {
-        write!(&mut control, " {}\n", line).unwrap();
-    }
-}
-
-/// Generates the copyright file needed by the package.
-fn generate_copyright(options: &Config) {
-    // The directory where the copyright file is stored is named after the name of the package.
-    let directory = PathBuf::from("target/debian/usr/share/doc/").join(options.name.clone());
-    // Create the directories needed by the copyright file
-    fs::create_dir_all(&directory)
-        .try("cargo-deb: unable to create `target/debian/usr/share/doc/<package>/`");
-    // Open the copyright file for writing
-    let mut copyright = fs::OpenOptions::new().create(true).write(true).truncate(true).open(&directory.join("copyright"))
-        .try("cargo-deb: could not create target/debian/DEBIAN/copyright");
-    // Write the information required by the copyright file to the newly created copyright file.
-    copyright.write(b"Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n").unwrap();
-    write!(&mut copyright, "Upstream Name: {}\n", options.name).unwrap();
-    write!(&mut copyright, "Source: {}\n", options.repository).unwrap();
-    write!(&mut copyright, "Copyright: {}\n", options.copyright).unwrap();
-    write!(&mut copyright, "License: {}\n", options.license).unwrap();
-    // Attempt to obtain the path of the license file
-    options.license_file.get(0)
-        // Fail if the path cannot be found and report that the license file argument is missing.
-        .map_or_else(|| failed("cargo-deb: missing license file argument"), |path| {
-            // Now we need to obtain the amount of lines to skip at the top of the file.
-            let lines_to_skip = options.license_file.get(1)
-                // If no argument is given, or if the argument is not a number, return 0.
-                .map_or(0, |x| x.parse::<usize>().unwrap_or(0));
-            // Now we need to attempt to open the file.
-            let mut file = fs::File::open(path).try("cargo-deb: license file could not be opened");
-            // The capacity of the file can be obtained from the metadata.
-            let capacity = file.metadata().map(|x| x.len()).unwrap_or(0) as usize;
-            // We are going to store the contents of the license file in a single string with the size of file.
-            let mut license_string = String::with_capacity(capacity);
-            // Attempt to read the contents of the license file into the license string.
-            file.read_to_string(&mut license_string).try("cargo-deb: error reading license file");
-            // Skip the first `A` number of lines and then iterate each line after that.
-            for line in license_string.lines().skip(lines_to_skip) {
-                // If the line is empty, write a dot, else write the line.
-                if line.is_empty() {
-                    copyright.write(b".\n").unwrap();
-                } else {
-                    write!(&mut copyright, "{}\n", line.trim()).unwrap();
-                }
-            }
+// Creates the debian-binary file that will be added to the final ar archive.
+fn generate_debian_binary_file() {
+    fs::OpenOptions::new().create(true).write(true).truncate(true).mode(CHMOD_FILE)
+        .open("target/debian/debian-binary").ok()
+        .map_or_else(|| failed("cargo-deb: unable to create target/debian/debian-binary"), |mut file| {
+            file.write(&[50, 46, 48, 10]).unwrap(); // [2][.][0][BS]
         });
-
-    // Sets the permissions of the copyright file to `644`.
-    let c_string = CString::new(directory.join("copyright").to_str().unwrap()).unwrap();
-    let status = unsafe { libc::chmod(c_string.as_ptr(), u32::from_str_radix("644", 8).unwrap()) };
-    if status < 0 { failed("cargo-deb: chmod error occurred in creating copyright file"); }
 }
 
-/// Creates a debian directory and copies the files that are needed by the package.
-fn copy_files(assets: &[Vec<String>]) {
-    fs::create_dir_all("target/debian/DEBIAN").try("cargo-deb: unable to create the 'target/debian/DEBIAN' directory");
-    // Copy each of the assets into the target/debian directory listed in the assets parameter
-    for asset in assets {
-        // Obtain the target directory of the current asset.
-        let mut target = asset.get(1).map_or_else(|| failed("cargo-deb: missing target directory"), |target| {
-            if target.starts_with('/') {
-                String::from("target/debian") + target.as_str()
-            } else {
-                String::from("target/debian/") + target.as_str()
-            }
-        });
-
-        // Determine if the target is a directory or if the last argument is what to rename the file as.
-        let target_is_dir = target.ends_with('/');
-        // Create the target directory needed by the current asset.
-        create_directory(&target, target_is_dir);
-        // Obtain a reference to the source argument.
-        let source = &asset[0];
-        // Append the file name to the target directory path if the file is not to be renamed.
-        if target_is_dir { target = target.clone() + Path::new(source).file_name().unwrap().to_str().unwrap(); }
-        // Attempt to copy the file from the source path to the target path.
-        match copy_file(source.as_str(), target.as_str(), asset) {
-            Some(CopyError::CopyFailed) => {
-                failed(format!("cargo-deb: unable to copy {} to {}", &source, &target))
-            },
-            Some(CopyError::ChmodMissing) => {
-                failed(format!("cargo-deb: chmod argument is missing from asset: {:?}", asset))
-            },
-            Some(CopyError::ChmodInvalid(chmod)) => {
-                failed(format!("cargo-deb: chmod argument is invalid: {}", chmod))
-            },
-            Some(CopyError::ChmodError(chmod)) => {
-                failed(format!("cargo-deb: chmod failed: {}", chmod))
-            },
-            _ => ()
-        }
-    }
-}
-
-/// Attempt to create the directory neede by the target.
-fn create_directory(target: &str, is_dir: bool) {
-    if is_dir {
-        fs::create_dir_all(target).try(&format!("cargo-deb: unable to create the {:?} directory", target));
-    } else {
-        let parent = Path::new(target).parent().unwrap();
-        fs::create_dir_all(parent).try(&format!("cargo-deb: unable to create the {:?} directory", target));
-    }
-}
-
-/// Attempt to copy the source file to the target path.
-fn copy_file(source: &str, target: &str, asset: &[String]) -> Option<CopyError> {
-    fs::copy(source, target).ok()
-        // If the file could not be copied, return the `CopyFailed` error
-        .map_or(Some(CopyError::CopyFailed), |_| {
-            // Attempt to collect the chmod argument, which is the third argument.
-            asset.get(2)
-                // If the chmod argument is missing, return `Some(CopyError::ChmodMissing)`
-                .map_or(Some(CopyError::ChmodMissing), |chmod| {
-                    // Obtain the octal representation of the chmod argument.
-                    u32::from_str_radix(chmod.as_str(), 8).ok()
-                        // Return that the value is invalid and return the invalid argument if it is invalid.
-                        .map_or(Some(CopyError::ChmodInvalid(chmod.clone())), |chmod| {
-                            // Execute the system's chmod command and collect the exit status.
-                            let c_string = CString::new(target).unwrap();
-                            let status = unsafe { libc::chmod(c_string.as_ptr(), chmod) };
-                            // If the exit status is less than zero, return an error, else return `None`.
-                            if status < 0 { Some(CopyError::ChmodError(chmod)) } else { None }
-                        })
-                })
-        })
-
+/// Removes the target/debian directory so that we can start fresh.
+fn remove_leftover_files() {
+    let _ = fs::remove_dir_all("target/debian");
+    fs::create_dir_all("target/debian").try("cargo-deb: unable to create debian target");
 }
 
 /// Builds a release binary with `cargo build --release`
-fn cargo_build(name: &str) {
+fn cargo_build() {
     Command::new("cargo").arg("build").arg("--release").status().try("cargo-deb: failed to build project");
-    Command::new("strip").arg("--strip-unneeded")
-        .arg(String::from("target/release/") + name)
+}
+
+// Strips the binary that was created with cargo
+fn strip_binary(name: &str) {
+    Command::new("strip").arg("--strip-unneeded").arg(String::from("target/release/") + name)
         .status().try("cargo-deb: could not strip binary");
 }

--- a/src/try.rs
+++ b/src/try.rs
@@ -12,10 +12,8 @@ impl<T, U: Error> Try for Result<T, U> {
     type Succ = T;
 
     fn try(self, error: &str) -> T {
-        self.unwrap_or_else(|_| {
-            let mut stderr = io::stderr();
-            stderr.write(error.as_bytes()).unwrap();
-            stderr.flush().unwrap();
+        self.unwrap_or_else(|reason| {
+            let _ = writeln!(&mut io::stderr(), "{}: {}", error, reason.to_string());
             exit(1);
         })
     }
@@ -26,9 +24,7 @@ impl<T> Try for Option<T> {
 
     fn try(self, error: &str) -> T {
         self.unwrap_or_else(|| {
-            let mut stderr = io::stderr();
-            stderr.write(error.as_bytes()).unwrap();
-            stderr.flush().unwrap();
+            let _ = writeln!(&mut io::stderr(), "{}", error);
             exit(1);
         })
     }
@@ -36,8 +32,6 @@ impl<T> Try for Option<T> {
 
 pub fn failed<T: AsRef<str>>(input: T) -> ! {
     let input = input.as_ref();
-    let mut stderr = io::stderr();
-    stderr.write(input.as_bytes()).unwrap();
-    stderr.flush().unwrap();
+    let _ = writeln!(&mut io::stderr(), "{}", input);
     exit(1);
 }


### PR DESCRIPTION
This commit will bring a large number of changes that overhauls the
feature set of the cargo deb subcommand. The critical feature of this
commit is that there is no longer a dependency on Debian packaging
utilities to package for Debian. It is therefore possible to build
Debian packages on non-Debian platforms, but Debian platforms will have
access to automatic dependency resolution as a key advantage.

- Enable the ability to automatically generate dependency information by
  adding "$auto" as part of the dependency string.
- Eliminate the usage of dpkg --build by manually creating the archives
- Take advantage of the Rust implementation of Zopfli for native Gzip
  compression of the control.tar archive.
- Utilize the rust-lzma crate to perform xz compression of the data.tar
  archive. A native Rust implementation of xz is wanted.
- Refactored a large portion of the code and added better error message
  handling.