### PR TITLE
Allow maintainer scripts to be configured and packaged

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,9 @@ pub struct Config {
     /// A list of configuration files installed by the package.
     pub conf_files: Option<String>,
     /// All of the files that are to be packaged. `{ source_file, target_path, chmod }`
-    pub assets: Vec<Vec<String>>
+    pub assets: Vec<Vec<String>>,
+    /// The path were possible maintainer scripts live
+    pub maintainer_scripts: Option<PathBuf>,
 }
 
 impl Config {
@@ -81,6 +83,7 @@ impl Cargo {
             conf_files: self.package.metadata.deb.conf_files.clone()
                 .map(|x| x.iter().fold(String::new(), |a, b| a + b + "\n")),
             assets: self.package.metadata.deb.assets.clone(),
+            maintainer_scripts: self.package.metadata.deb.maintainer_scripts.clone().map(|s| PathBuf::from(s))
         }
     }
 
@@ -120,6 +123,7 @@ pub struct CargoDeb {
     pub priority: String,
     pub conf_files: Option<Vec<String>>,
     pub assets: Vec<Vec<String>>,
+    pub maintainer_scripts: Option<String>
 }
 
 /// Returns the path of the `Cargo.toml` that we want to build.


### PR DESCRIPTION
This change allows the definition of a path where maintainer scripts reside inside the `package.metadata.deb` table.
In that path files with names `preinst`, `postinst`, `prerm` and `postrm` are packaged into the control folder of the debian package. These files are then executed during the installation/upgrade/removal process.