### PR TITLE
Package dependencies handling improvements, --no-strip command line parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,9 @@ fn main() {
     if !std::env::args().any(|x| x.as_str() == "--no-build") {
         cargo_build(&options.features, options.default_features);
     }
-    strip_binary(options.name.as_str());
+    if !std::env::args().any(|x| x.as_str() == "--no-strip") {
+        strip_binary(options.name.as_str());
+    }
 
     // Obtain the current time which will be used to stamp the generated files in the archives.
     let system_time = time::SystemTime::now().duration_since(time::UNIX_EPOCH)


### PR DESCRIPTION
1. Improved package dependencies handling. An apt-cache output is localised so splitting by whitespaces doesn't work because it is possible there are multiple words on localised versions. For example on Czech Debian:

    jag@scqp:~$ apt-cache policy zlib1g
    zlib1g:
      Instalovaná verze: 1:1.2.8.dfsg-5  

2. Added --no-strip command line parameter. It is useful to get full backtrace with RUST_BACKTRACE=1.