### PR TITLE
change: path to "strip" command data format

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -41,4 +41,3 @@ pub fn xz_or_gz(data: &[u8], base_path: &Path) -> CDResult<PathBuf> {
 pub fn xz_or_gz(data: &[u8], base_path: &Path) -> CDResult<PathBuf> {
     gz(data, base_path)
 }
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ impl CargoConfig {
 
     pub fn strip_command(&self, target_triple: &str) -> Option<Cow<str>> {
         if let Some(target) = self.target_conf(target_triple) {
-            if let Some(strip) = target.get("strip").and_then(|s|s.as_str()) {
+            if let Some(strip) = target.get("strip").and_then(|s|s.get("path")).and_then(|s|s.as_str()) {
                 return Some(Cow::Borrowed(strip));
             }
         }


### PR DESCRIPTION
make `cargo-deb` changes to accepts format of `strip` command like below:

```toml
[target.arm-unknown-linux-gnueabihf]
linker = "armv6-rpi-linux-gnueabifh-gcc"
strip = { path = "armv6-rpi-linux-gnueabihf-strip" }
```

Also, the `cargo` command accepts above format too.

But the latest `cargo-deb` only accepts format like below:

```toml
[target.arm-unknown-linux-gnueabihf]
linker = "armv6-rpi-linux-gnueabifh-gcc"
strip = "armv6-rpi-linux-gnueabihf-strip"
```

also, the `cargo` command *reject* above format like below.

```sh
/project$ cargo build --target=arm-unknown-linux-gnueabihf
error: expected a table, but found a string for `strip` in /project/.cargo/config
```
