### PR TITLE
Looking for VFP Registers to distinguish between armel and armhf

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::num;
 use std::time;
+use std::string;
 use std::path::PathBuf;
 use toml;
 use serde_json;
@@ -78,6 +79,12 @@ quick_error! {
             from()
             description(err.description())
             display("unable to iterate asset glob result")
+            cause(err)
+        }
+        Utf8Error(err: string::FromUtf8Error) {
+            from()
+            description(err.description())
+            display("unable to convert utf8 into string")
             cause(err)
         }
     }


### PR DESCRIPTION
Using cargo-deb on a recent raspberry-pi causes the resulting .deb to be for the target architecture of `armel`, even though recent raspberry-pis are of architecture `armhf`. So using cargo-deb on a raspberry-pi results in a package that isn't install-able on the raspberry-pi. It would also cause panics like the following: 

 ```
   Finished release [optimized] target(s) in 1436.44 secs
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CommandError("dpkg-query (get package version)", "zlib1g:armel", [100, 112, 107, 103, 45, 113, 117, 101, 114, 121, 58, 32, 110, 111, 32, 112, 97, 99, 107, 97, 103, 101, 115, 32, 102, 111, 117, 110, 100, 32, 109, 97, 116, 99, 104, 105, 110, 103, 32, 122, 108, 105, 98, 49, 103, 58, 97, 114, 109, 101, 108, 10])', /checkout/src/libcore/result.rs:916:5

```
I am not a hardware guru, but it appears that a difference between `armhf` and `armel` is the presents of the VFP registers [1][2]. I added a function to explicitly look for VFP registers using `readelf`[1]. This may not be the best way to determine `armhf` v `armel`, so i'm open to other ideas. 

The result of this patch is that using cargo-deb on a raspberry-pi will produce a package (albeit very slowly) that will install on the raspberry-pi, and avoid the panic mentioned above.

[1] https://www.raspberrypi.org/forums/viewtopic.php?t=20873
[2] https://www.raspberrypi.org/forums/viewtopic.php?t=3641