### PR TITLE
Allow package variants with different metadata

### DIFF
--- a/example/4.txt
+++ b/example/4.txt
@@ -1,0 +1,1 @@
+hello variant debug

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -20,3 +20,13 @@ assets = [
     ["3.txt", "var/lib/example/3.txt", "644"],
 ]
 changelog = "changelog"
+
+
+[package.metadata.deb.variants.debug]
+assets =  [
+    # binary
+    ["target/release/example", "usr/bin/", "755"],
+    # assets
+    ["assets/*", "var/lib/example", "644"],
+    ["4.txt", "var/lib/example/4.txt", "644"],
+]

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ quick_error! {
         }
         VariantNotFound(variant: String) {
             description("unable to find the passed metadata variant")
-            display("variant '{}' not found in package.metadata.deb_variant", variant)
+            display("variant '{}' not found in package.metadata.deb.variants", variant)
         }
         GlobPatternError(err: glob::PatternError) {
             from()

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,10 @@ quick_error! {
             description("unable to find package for the library")
             display("path '{}' does not belong to a package: {}", path, String::from_utf8_lossy(reason))
         }
+        VariantNotFound(variant: String) {
+            description("unable to find the passed metadata variant")
+            display("variant '{}' not found in package.metadata.debv", variant)
+        }
         GlobPatternError(err: glob::PatternError) {
             from()
             description(err.description())

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ quick_error! {
         }
         VariantNotFound(variant: String) {
             description("unable to find the passed metadata variant")
-            display("variant '{}' not found in package.metadata.debv", variant)
+            display("variant '{}' not found in package.metadata.deb_variant", variant)
         }
         GlobPatternError(err: glob::PatternError) {
             from()

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -332,7 +332,8 @@ impl Cargo {
 
         // If we build against a variant use that config and change the package name
         let mut deb = if let Some(variant) = variant {
-            self.package.name = format!("{}_{}", self.package.name, variant);
+            // Use dash as underscore is not allowed in package names
+            self.package.name = format!("{}-{}", self.package.name, variant);
             let mut variants = self.package.metadata.take().and_then(|m| m.deb_variant)
                 .ok_or(CargoDebError::VariantNotFound(variant.to_string()))?;
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -37,20 +37,25 @@ impl AssetSource {
     pub fn len(&self) -> Option<u64> {
         match *self {
             // FIXME: may not be accurate if the executable is not stripped yet?
-            AssetSource::Path(ref p) => fs::metadata(p).ok().map(|m| m.len()),
-            AssetSource::Data(ref d) => Some(d.len() as u64),
+            AssetSource::Path(ref p) => {
+                fs::metadata(p).ok().map(|m| m.len())
+            },
+            AssetSource::Data(ref d) => {
+                Some(d.len() as u64)
+            },
         }
     }
 
     pub fn data(&self) -> CDResult<Cow<[u8]>> {
         Ok(match *self {
             AssetSource::Path(ref p) => {
-                let data = file::get(p).map_err(|e| {
-                    CargoDebError::IoFile("unable to read asset to add to archive", e, p.to_owned())
-                })?;
+                let data = file::get(p)
+                    .map_err(|e| CargoDebError::IoFile("unable to read asset to add to archive", e, p.to_owned()))?;
                 Cow::Owned(data)
-            }
-            AssetSource::Data(ref d) => Cow::Borrowed(d),
+            },
+            AssetSource::Data(ref d) => {
+                Cow::Borrowed(d)
+            },
         })
     }
 }
@@ -66,17 +71,11 @@ pub struct Asset {
 impl Asset {
     pub fn new(source: AssetSource, mut target_path: PathBuf, chmod: u32, is_built: bool) -> Self {
         if target_path.is_absolute() {
-            target_path = target_path
-                .strip_prefix("/")
-                .expect("no root dir")
-                .to_owned();
+            target_path = target_path.strip_prefix("/").expect("no root dir").to_owned();
         }
         // is_dir() is only for paths that exist
         if target_path.to_string_lossy().ends_with('/') {
-            let file_name = source
-                .path()
-                .and_then(|p| p.file_name())
-                .expect("source must be a file");
+            let file_name = source.path().and_then(|p| p.file_name()).expect("source must be a file");
             target_path = target_path.join(file_name);
         }
         Self {
@@ -92,8 +91,7 @@ impl Asset {
     }
 
     fn is_dynamic_library(&self) -> bool {
-        self.target_path
-            .file_name()
+        self.target_path.file_name()
             .and_then(|f| f.to_str())
             .map_or(false, |f| f.ends_with(DLL_SUFFIX))
     }
@@ -179,33 +177,18 @@ impl Config {
     /// Makes a new config from `Cargo.toml` in the current working directory.
     ///
     /// `None` target means the host machine's architecture.
-    pub fn from_manifest(
-        manifest_path: &Path,
-        target: Option<&str>,
-        variant: Option<&str>,
-        listener: &mut Listener,
-    ) -> CDResult<Config> {
+    pub fn from_manifest(manifest_path: &Path, target: Option<&str>, variant: Option<&str>, listener: &mut Listener) -> CDResult<Config> {
         let metadata = cargo_metadata(manifest_path)?;
         let root_id = metadata.resolve.root;
-        let root_package = metadata
-            .packages
-            .iter()
+        let root_package = metadata.packages.iter()
             .find(|p| p.id == root_id)
             .ok_or("Unable to find root package in cargo metadata")?;
         let target_dir = Path::new(&metadata.target_directory);
         let manifest_path = Path::new(&root_package.manifest_path);
         let manifest_dir = manifest_path.parent().unwrap();
-        let content = file::get_text(&manifest_path).map_err(|e| {
-            CargoDebError::IoFile("unable to read Cargo.toml", e, manifest_path.to_owned())
-        })?;
-        toml::from_str::<Cargo>(&content)?.into_config(
-            root_package,
-            manifest_dir,
-            target_dir,
-            target,
-            variant,
-            listener,
-        )
+        let content = file::get_text(&manifest_path)
+            .map_err(|e| CargoDebError::IoFile("unable to read Cargo.toml", e, manifest_path.to_owned()))?;
+        toml::from_str::<Cargo>(&content)?.into_config(root_package, manifest_dir, target_dir, target, variant, listener)
     }
 
     pub(crate) fn get_dependencies(&self, listener: &mut Listener) -> CDResult<String> {
@@ -219,12 +202,8 @@ impl Config {
                             deps.insert(dep);
                         },
                         Err(err) => {
-                            listener.warning(format!(
-                                "{} (no auto deps for {})",
-                                err,
-                                bname.display()
-                            ));
-                        }
+                            listener.warning(format!("{} (no auto deps for {})", err, bname.display()));
+                        },
                     };
                 }
             } else {
@@ -238,11 +217,8 @@ impl Config {
         let copyright_file = ::data::generate_copyright_asset(self)?;
         self.assets.push(Asset::new(
             AssetSource::Data(copyright_file),
-            Path::new("usr/share/doc")
-                .join(&self.name)
-                .join("copyright"),
-            0o644,
-            false,
+            Path::new("usr/share/doc").join(&self.name).join("copyright"),
+            0o644, false
         ));
         Ok(())
     }
@@ -253,11 +229,8 @@ impl Config {
             if let Some(changelog_file) = ::data::generate_changelog_asset(self)? {
                 self.assets.push(Asset::new(
                     AssetSource::Data(changelog_file),
-                    Path::new("usr/share/doc")
-                        .join(&self.name)
-                        .join("changelog.gz"),
-                    0o644,
-                    false,
+                    Path::new("usr/share/doc").join(&self.name).join("changelog.gz"),
+                    0o644, false
                 ));
             }
         }
@@ -275,19 +248,15 @@ impl Config {
     }
 
     fn binaries(&self, built_only: bool) -> Vec<&AssetSource> {
-        self.assets
-            .iter()
-            .filter_map(|asset| {
-                // Assumes files in build dir which have executable flag set are binaries
-                if (!built_only || asset.is_built)
-                    && (asset.is_dynamic_library() || asset.is_executable())
-                {
+        self.assets.iter().filter_map(|asset| {
+            // Assumes files in build dir which have executable flag set are binaries
+            if (!built_only || asset.is_built) &&
+                (asset.is_dynamic_library() || asset.is_executable()) {
                     Some(&asset.source)
-                } else {
-                    None
-                }
-            })
-            .collect()
+            } else {
+                None
+            }
+        }).collect()
     }
 
     /// Tries to guess type of source control used for the repo URL.
@@ -295,9 +264,7 @@ impl Config {
     /// user-friendly URLs or webpages instead of tool-specific URL schemes.
     pub(crate) fn repository_type(&self) -> Option<&str> {
         if let Some(ref repo) = self.repository {
-            if repo.starts_with("git+") || repo.ends_with(".git") || repo.contains("git@")
-                || repo.contains("github.com") || repo.contains("gitlab.com")
-            {
+            if repo.starts_with("git+") || repo.ends_with(".git") || repo.contains("git@") || repo.contains("github.com") || repo.contains("gitlab.com") {
                 return Some("Git");
             }
             if repo.starts_with("cvs+") || repo.contains("pserver:") || repo.contains("@cvs.") {
@@ -390,31 +357,17 @@ impl Cargo {
             license_file,
             license_file_skip_lines,
             copyright: deb.copyright.take().ok_or_then(|| {
-                Ok(self.package
-                    .authors
-                    .as_ref()
-                    .ok_or("Package must have a copyright or authors")?
-                    .join(", "))
+                Ok(self.package.authors.as_ref().ok_or("Package must have a copyright or authors")?.join(", "))
             })?,
             version: self.version_string(deb.revision),
             homepage: self.package.homepage.clone(),
             documentation: self.package.documentation.clone(),
             repository: self.package.repository.take(),
-            description: self.package
-                .description
-                .take()
-                .unwrap_or_else(|| format!("[generated from Rust crate {}]", self.package.name)),
-            extended_description: self.extended_description(
-                deb.extended_description.take(),
-                readme,
-            )?,
+            description: self.package.description.take().unwrap_or_else(||format!("[generated from Rust crate {}]", self.package.name)),
+            extended_description: self.extended_description(deb.extended_description.take(), readme)?,
             maintainer: deb.maintainer.take().ok_or_then(|| {
-                Ok(self.package
-                    .authors
-                    .as_ref()
-                    .and_then(|a| a.get(0))
-                    .ok_or("Package must have a maintainer or authors")?
-                    .to_owned())
+                Ok(self.package.authors.as_ref().and_then(|a|a.get(0))
+                    .ok_or("Package must have a maintainer or authors")?.to_owned())
             })?,
             depends: deb.depends.take().unwrap_or("$auto".to_owned()),
             conflicts: deb.conflicts.take(),
@@ -424,19 +377,14 @@ impl Cargo {
             section: deb.section.take(),
             priority: deb.priority.take().unwrap_or("optional".to_owned()),
             architecture: get_arch(target.unwrap_or(::DEFAULT_TARGET)).to_owned(),
-            conf_files: deb.conf_files
-                .map(|x| x.iter().fold(String::new(), |a, b| a + b + "\n")),
+            conf_files: deb.conf_files.map(|x| x.iter().fold(String::new(), |a, b| a + b + "\n")),
             assets: vec![],
             changelog: deb.changelog.take(),
             maintainer_scripts: deb.maintainer_scripts.map(PathBuf::from),
             features: deb.features.take().unwrap_or(vec![]),
             default_features: deb.default_features.unwrap_or(true),
-            strip: self.profile
-                .as_ref()
-                .and_then(|p| p.release.as_ref())
-                .and_then(|r| r.debug)
-                .map(|debug| !debug)
-                .unwrap_or(true),
+            strip: self.profile.as_ref().and_then(|p|p.release.as_ref())
+                .and_then(|r|r.debug).map(|debug|!debug).unwrap_or(true),
             _use_constructor_to_make_this_struct_: (),
         };
 
@@ -451,13 +399,7 @@ impl Cargo {
         Ok(config)
     }
 
-    fn check_config(
-        &self,
-        manifest_dir: &Path,
-        readme: Option<&String>,
-        deb: &CargoDeb,
-        listener: &mut Listener,
-    ) {
+    fn check_config(&self, manifest_dir: &Path, readme: Option<&String>, deb: &CargoDeb, listener: &mut Listener) {
         if self.package.description.is_none() {
             listener.warning("description field is missing in Cargo.toml".to_owned());
         }
@@ -465,89 +407,58 @@ impl Cargo {
             listener.warning("license field is missing in Cargo.toml".to_owned());
         }
         if let Some(readme) = readme {
-            if deb.extended_description.is_none()
-                && (readme.ends_with(".md") || readme.ends_with(".markdown"))
-            {
+            if deb.extended_description.is_none() && (readme.ends_with(".md") || readme.ends_with(".markdown")) {
                 listener.warning(format!("extended-description field missing. Using {}, but markdown may not render well.",readme));
             }
         } else {
             for p in &["README.md", "README.markdown", "README.txt", "README"] {
                 if manifest_dir.join(p).exists() {
-                    listener.warning(format!(
-                        "{} file exists, but is not specified in `readme` Cargo.toml field",
-                        p
-                    ));
+                    listener.warning(format!("{} file exists, but is not specified in `readme` Cargo.toml field", p));
                     break;
                 }
             }
         }
     }
 
-    fn extended_description(
-        &self,
-        desc: Option<String>,
-        readme: Option<&String>,
-    ) -> CDResult<Option<String>> {
+    fn extended_description(&self, desc: Option<String>, readme: Option<&String>) -> CDResult<Option<String>> {
         Ok(if desc.is_some() {
             desc
         } else if let Some(readme) = readme {
-            Some(file::get_text(readme).map_err(|err| {
-                CargoDebError::IoFile("unable to read README", err, PathBuf::from(readme))
-            })?)
+            Some(file::get_text(readme)
+                .map_err(|err| CargoDebError::IoFile("unable to read README", err, PathBuf::from(readme)))?)
         } else {
             None
         })
     }
 
-    fn license_file(
-        &mut self,
-        license_file: Option<&Vec<String>>,
-    ) -> CDResult<(Option<PathBuf>, usize)> {
+    fn license_file(&mut self, license_file: Option<&Vec<String>>) -> CDResult<(Option<PathBuf>, usize)> {
         if let Some(args) = license_file {
             let mut args = args.iter();
             let file = args.next();
             let lines = if let Some(lines) = args.next() {
-                lines
-                    .parse()
-                    .map_err(|e| CargoDebError::NumParse("invalid number of lines", e))?
-            } else {
-                0
-            };
-            Ok((file.map(|s| s.into()), lines))
+                lines.parse().map_err(|e| CargoDebError::NumParse("invalid number of lines", e))?
+            } else {0};
+            Ok((file.map(|s|s.into()), lines))
         } else {
-            Ok((self.package.license_file.as_ref().map(|s| s.into()), 0))
+            Ok((self.package.license_file.as_ref().map(|s|s.into()), 0))
         }
     }
 
-    fn take_assets(
-        &self,
-        options: &Config,
-        assets: Option<Vec<Vec<String>>>,
-        targets: &[CargoMetadataTarget],
-        readme: Option<&String>,
-    ) -> CDResult<Vec<Asset>> {
+    fn take_assets(&self, options: &Config, assets: Option<Vec<Vec<String>>>, targets: &[CargoMetadataTarget], readme: Option<&String>) -> CDResult<Vec<Asset>> {
         Ok(if let Some(assets) = assets {
             let mut all_assets = Vec::with_capacity(assets.len());
             for mut v in assets {
                 let mut v = v.drain(..);
-                let mut source_path = PathBuf::from(v.next()
-                    .ok_or("missing path (first array entry) for asset in Cargo.toml")?);
-                let (is_built, source_path) =
-                    if let Ok(rel_path) = source_path.strip_prefix("target/release") {
-                        (true, options.path_in_build(rel_path))
-                    } else {
-                        (false, options.path_in_workspace(&source_path))
-                    };
-                let target_path = PathBuf::from(v.next()
-                    .ok_or("missing target (second array entry) for asset in Cargo.toml")?);
-                let mode =
-                    u32::from_str_radix(
-                        &v.next()
-                            .ok_or("missing chmod (third array entry) for asset in Cargo.toml")?,
-                        8,
-                    ).map_err(|e| CargoDebError::NumParse("unable to parse chmod argument", e))?;
-                let source_prefix: PathBuf = source_path
-                    .iter()
+                let mut source_path = PathBuf::from(v.next().ok_or("missing path (first array entry) for asset in Cargo.toml")?);
+                let (is_built, source_path) = if let Ok(rel_path) = source_path.strip_prefix("target/release") {
+                    (true, options.path_in_build(rel_path))
+                } else {
+                    (false, options.path_in_workspace(&source_path))
+                };
+                let target_path = PathBuf::from(v.next().ok_or("missing target (second array entry) for asset in Cargo.toml")?);
+                let mode = u32::from_str_radix(&v.next().ok_or("missing chmod (third array entry) for asset in Cargo.toml")?, 8)
+                    .map_err(|e| CargoDebError::NumParse("unable to parse chmod argument", e))?;
+                let source_prefix: PathBuf = source_path.iter()
                     .take_while(|part| !is_glob_pattern(part.to_str().unwrap()))
                     .collect();
                 let source_is_glob = is_glob_pattern(source_path.to_str().unwrap());
@@ -583,7 +494,7 @@ impl Cargo {
                         AssetSource::Path(source_file),
                         target_file,
                         mode,
-                        is_built,
+                        is_built
                     ));
                 }
             }
@@ -592,25 +503,19 @@ impl Cargo {
             let mut implied_assets: Vec<_> = targets
                 .iter()
                 .filter_map(|t| {
-                    if t.crate_types.iter().any(|ty| ty == "bin")
-                        && t.kind.iter().any(|k| k == "bin")
-                    {
+                    if t.crate_types.iter().any(|ty|ty=="bin") && t.kind.iter().any(|k|k=="bin") {
                         Some(Asset::new(
                             AssetSource::Path(options.path_in_build(&t.name)),
                             Path::new("usr/bin").join(&t.name),
-                            0o755,
-                            true,
+                            0o755, true
                         ))
-                    } else if t.crate_types.iter().any(|ty| ty == "cdylib")
-                        && t.kind.iter().any(|k| k == "cdylib")
-                    {
+                    } else if t.crate_types.iter().any(|ty|ty=="cdylib") && t.kind.iter().any(|k|k=="cdylib") {
                         // FIXME: std has constants for the host arch, but not for cross-compilation
                         let lib_name = format!("{}{}{}", DLL_PREFIX, t.name, DLL_SUFFIX);
                         Some(Asset::new(
                             AssetSource::Path(options.path_in_build(&lib_name)),
                             Path::new("usr/lib").join(lib_name),
-                            0o644,
-                            true,
+                            0o644, true
                         ))
                     } else {
                         None
@@ -618,14 +523,11 @@ impl Cargo {
                 })
                 .collect();
             if let Some(readme) = readme {
-                let target_path = Path::new("usr/share/doc")
-                    .join(&self.package.name)
-                    .join(readme);
+                let target_path = Path::new("usr/share/doc").join(&self.package.name).join(readme);
                 implied_assets.push(Asset::new(
                     AssetSource::Path(PathBuf::from(readme)),
                     target_path,
-                    0o644,
-                    false,
+                    0o644, false
                 ));
             }
             implied_assets
@@ -665,12 +567,12 @@ struct CargoPackageMetadata {
 
 #[derive(Clone, Debug, Deserialize)]
 struct CargoProfiles {
-    pub release: Option<CargoProfile>,
+    pub release: Option<CargoProfile>
 }
 
 #[derive(Clone, Debug, Deserialize)]
 struct CargoProfile {
-    pub debug: Option<bool>,
+    pub debug: Option<bool>
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -740,11 +642,7 @@ fn cargo_metadata(manifest_path: &Path) -> CDResult<CargoMetadata> {
     let output = cmd.output()
         .map_err(|e| CargoDebError::CommandFailed(e, "cargo (is it in your PATH?)"))?;
     if !output.status.success() {
-        return Err(CargoDebError::CommandError(
-            "cargo",
-            "metadata".to_owned(),
-            output.stderr,
-        ));
+        return Err(CargoDebError::CommandError("cargo", "metadata".to_owned(), output.stderr));
     }
 
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -761,7 +659,7 @@ fn get_arch(target: &str) -> &str {
         // https://wiki.debian.org/Multiarch/Tuples
         // rustc --print target-list
         // https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
-        ("aarch64", _) => "arm64",
+        ("aarch64", _)          => "arm64",
         ("mips64", "gnuabin32") => "mipsn32",
         ("mips64el", "gnuabin32") => "mipsn32el",
         ("mipsisa32r6", _) => "mipsr6",
@@ -771,9 +669,11 @@ fn get_arch(target: &str) -> &str {
         ("mipsisa64r6el", "gnuabi64") => "mips64r6el",
         ("mipsisa64r6el", "gnuabin32") => "mipsn32r6el",
         ("powerpc", "gnuspe") => "powerpcspe",
-        ("powerpc64", _) => "ppc64",
+        ("powerpc64", _)   => "ppc64",
         ("powerpc64le", _) => "ppc64el",
-        ("i586", _) | ("i686", _) | ("x86", _) => "i386",
+        ("i586", _) |
+        ("i686", _) |
+        ("x86", _)   => "i386",
         ("x86_64", "gnux32") => "x32",
         ("x86_64", _) => "amd64",
         (arm, gnueabi) if arm.starts_with("arm") && gnueabi.ends_with("hf") => "armhf",
@@ -792,8 +692,7 @@ fn assets() {
     let a = Asset::new(
         AssetSource::Path(PathBuf::from("target/release/bar")),
         PathBuf::from("baz/"),
-        0o644,
-        true,
+        0o644, true
     );
     assert_eq!("baz/bar", a.target_path.to_str().unwrap());
     assert!(a.is_built);
@@ -801,8 +700,7 @@ fn assets() {
     let a = Asset::new(
         AssetSource::Path(PathBuf::from("foo/bar")),
         PathBuf::from("/baz/quz"),
-        0o644,
-        false,
+        0o644, false
     );
     assert_eq!("baz/quz", a.target_path.to_str().unwrap());
     assert!(!a.is_built);

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,9 +1,9 @@
 #![allow(unused_imports)]
-extern crate tempdir;
 extern crate file;
+extern crate tempdir;
 use std::env;
 use std::process::Command;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use tempdir::TempDir;
 
 #[test]
@@ -29,7 +29,6 @@ fn run_cargo_deb_command_on_example_dir() {
         .arg("-x")
         .arg(deb_path)
         .status().unwrap().success());
-
 
     assert_eq!("2.0\n", file::get_text(ardir.path().join("debian-binary")).unwrap());
     assert!(ardir.path().join("data.tar.xz").exists());
@@ -69,5 +68,75 @@ fn run_cargo_deb_command_on_example_dir() {
     assert!(ddir.path().join("var/lib/example/3.txt").exists());
     assert!(ddir.path().join("usr/share/doc/example/copyright").exists());
     assert!(ddir.path().join("usr/share/doc/example/changelog.gz").exists());
+    assert!(ddir.path().join("usr/bin/example").exists());
+}
+
+#[test]
+#[cfg(all(feature = "lzma", target_os = "linux"))]
+fn run_cargo_deb_command_on_example_dir_with_variant() {
+    let root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let cmd_path = root.join("target/debug/cargo-deb");
+    assert!(cmd_path.exists());
+    let output = Command::new(cmd_path)
+        .arg("--variant=debug")
+        .arg(format!(
+            "--manifest-path={}",
+            root.join("example/Cargo.toml").display()
+        ))
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // prints deb path on the last line
+    let last_line = output.stdout[..output.stdout.len()-1].split(|&c| c==b'\n').last().unwrap();
+    let deb_path = Path::new(::std::str::from_utf8(last_line).unwrap());
+    assert!(deb_path.exists());
+
+    let ardir = TempDir::new("cargo-deb-test").unwrap();
+    assert!(ardir.path().exists());
+    assert!(Command::new("ar")
+        .current_dir(ardir.path())
+        .arg("-x")
+        .arg(deb_path)
+        .status().unwrap().success());
+
+    assert_eq!("2.0\n", file::get_text(ardir.path().join("debian-binary")).unwrap());
+    assert!(ardir.path().join("data.tar.xz").exists());
+    assert!(ardir.path().join("control.tar.gz").exists());
+
+    let cdir = TempDir::new("cargo-control-test").unwrap();
+    assert!(Command::new("tar")
+        .arg("xzf")
+        .current_dir(cdir.path())
+        .arg(ardir.path().join("control.tar.gz"))
+        .status().unwrap().success());
+
+    let control = file::get_text(cdir.path().join("control")).unwrap();
+    assert!(control.contains("Package: example-debug\n"));
+    assert!(control.contains("Version: 0.1.0\n"));
+    assert!(control.contains("Section: utils\n"));
+    assert!(control.contains("Architecture: "));
+    assert!(control.contains("Maintainer: cargo-deb developers <cargo-deb@example.invalid>\n"));
+
+    let md5sums = file::get_text(cdir.path().join("md5sums")).unwrap();
+    assert!(md5sums.contains(" usr/bin/example\n"));
+    assert!(md5sums.contains(" usr/share/doc/example-debug/changelog.gz\n"));
+    assert!(md5sums.contains("b1946ac92492d2347c6235b4d2611184  var/lib/example/1.txt\n"));
+    assert!(md5sums.contains("591785b794601e212b260e25925636fd  var/lib/example/2.txt\n"));
+    assert!(md5sums.contains("835a3c46f2330925774ebf780aa74241  var/lib/example/4.txt\n"));
+    assert!(md5sums.contains("9a6e2d2dd978ea60b29260416ee09dbc  usr/share/doc/example-debug/copyright\n"));
+
+    let ddir = TempDir::new("cargo-data-test").unwrap();
+    assert!(Command::new("tar")
+        .arg("xJf")
+        .current_dir(ddir.path())
+        .arg(ardir.path().join("data.tar.xz"))
+        .status().unwrap().success());
+
+    assert!(ddir.path().join("var/lib/example/1.txt").exists());
+    assert!(ddir.path().join("var/lib/example/2.txt").exists());
+    assert!(ddir.path().join("var/lib/example/4.txt").exists());
+    assert!(ddir.path().join("usr/share/doc/example-debug/copyright").exists());
+    assert!(ddir.path().join("usr/share/doc/example-debug/changelog.gz").exists());
     assert!(ddir.path().join("usr/bin/example").exists());
 }


### PR DESCRIPTION
This changes allows different package metadata variants.
Our use-case are test and live configurations where `assets`, `conf_files` and `maintainer_scripts` may be different.

The variant name is added to the package name:
`package-name_variant-name_version-string`

Variants can be defined inside `Cargo.toml` in the `package.metadata.deb_variant` map.

Packaging a variant is as simple as `cargo deb --variant <VariantName>`