### PR TITLE
Remove unnecessary field from variant PR

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -579,7 +579,6 @@ struct CargoPackage {
 #[derive(Clone, Debug, Deserialize)]
 struct CargoPackageMetadata {
     pub deb: Option<CargoDeb>,
-    pub deb_variant: Option<HashMap<String, CargoDeb>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
The `deb_variant` field was introduced in PR #61 but was never used because the syntax changed.
This commit removes that old field.