### PR TITLE
Fail on unknown fields in `package.metadata.deb`

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -600,7 +600,7 @@ struct CargoBin {
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct CargoDeb {
     pub maintainer: Option<String>,
     pub copyright: Option<String>,


### PR DESCRIPTION
This results in cargo-deb failing when a field in `package.metadata.deb` is misspelled.
Which is a huge help when failing to recognize that `maintainer_scripts` should actually be `maintainer-scripts`