### PR TITLE
Fix profile.X.debug casting

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -402,8 +402,11 @@ impl Cargo {
             default_features: deb.default_features.unwrap_or(true),
             strip: self.profile.as_ref().and_then(|p|p.release.as_ref())
                 .and_then(|r| r.debug.as_ref())
-                .and_then(|debug| debug.as_bool())
-                .unwrap_or(true),
+                .map_or(true, |debug| match debug {
+                    toml::Value::Integer(0) => false,
+                    toml::Value::Boolean(_) => debug.as_bool().unwrap(),
+                    _ => true
+                }),
             _use_constructor_to_make_this_struct_: (),
         };
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -404,7 +404,7 @@ impl Cargo {
                 .and_then(|r| r.debug.as_ref())
                 .map_or(true, |debug| match debug {
                     toml::Value::Integer(0) => false,
-                    toml::Value::Boolean(_) => debug.as_bool().unwrap(),
+                    toml::Value::Boolean(value) => *value,
                     _ => true
                 }),
             _use_constructor_to_make_this_struct_: (),


### PR DESCRIPTION
As it can be an `u32`, `0` should be interpreted as false.

Since 4bd257dbd9700b1b587619c0938f2013e6e25e0d both types are parsed correctly (not included in latest release 1.10.0)

Fixes #68 