### PR TITLE
Speedup Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: rust
-addons:
-  apt:
-    packages:
-      - liblzma-dev
+cache: cargo
 script:
   - cargo test --all
-  - cargo install --path .
+  - cargo install --path . --force
   - cd example && cargo deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: rust
 cache: cargo
 script:
   - cargo test --all
-  - cargo install --path . --force
-  - cd example && cargo deb


### PR DESCRIPTION
1. Use cache
2. Do not install unneeded liblzma-dev
3. Do not run `cargo deb` on example project twice (One run is already performed in run_cargo_deb_command_on_example_dir test)

Before: 6m
After: 1m 30s