### PR TITLE
debarchive: set UID/GID to 0/0

### DIFF
--- a/src/debarchive.rs
+++ b/src/debarchive.rs
@@ -41,6 +41,8 @@ impl DebArchive {
         let mut header = Header::new(dest_path.as_bytes().to_owned(), data.len() as u64);
         header.set_mode(0o644);
         header.set_mtime(mtime_timestamp);
+        header.set_uid(0);
+        header.set_gid(0);
         self.ar_builder.append(&header, data)?;
         Ok(())
     }


### PR DESCRIPTION
Prior to this change, the ar file embeds the UID and GID of the invoking user inside the deb archive.  After this change, the files in the archive are owned by root.

In deb archives generated by standard Debian build tools (like dpkg-buildpackage), the binary rule that generates the archive runs as root (or with fakeroot).  Because the binary rule runs as root, the contents of the ar file have UID and GID of 0.

Prior to this change, I was seeing corrupt deb files (unable to be opened with `dpkg --contents` or with `ar`).  When examining the files with hexdump and comparing to a deb file that I manually generated with `ar`, I saw my UID and GID embedded in the file.  Since I typically use a system with very high UID and GIDs, I suspect that the long UID and GID were overflowing the UID and GID fields in the archive.  This change allows the archive to be created properly and matches other deb archives that I see in Ubuntu packages.