### PR TITLE
Not trim license body

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -51,9 +51,9 @@ pub(crate) fn generate_copyright_asset(options: &Config) -> CDResult<Vec<u8>> {
             .map_err(|e| CargoDebError::IoFile("unable to read license file", e, path.to_owned()))?;
         // Skip the first `A` number of lines and then iterate each line after that.
         for line in license_string.lines().skip(options.license_file_skip_lines) {
-            // If the line is empty, write a dot, else write the line.
-            if line.is_empty() {
-                copyright.write_all(b".\n")?;
+            // If the line is a space, add a dot, else write the line.
+            if line == " " {
+                copyright.write_all(b" .\n")?;
             } else {
                 copyright.write_all(line.as_bytes())?;
                 copyright.write_all(b"\n")?;

--- a/src/data.rs
+++ b/src/data.rs
@@ -55,7 +55,7 @@ pub(crate) fn generate_copyright_asset(options: &Config) -> CDResult<Vec<u8>> {
             if line.is_empty() {
                 copyright.write_all(b".\n")?;
             } else {
-                copyright.write_all(line.trim().as_bytes())?;
+                copyright.write_all(line.as_bytes())?;
                 copyright.write_all(b"\n")?;
             }
         }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -54,7 +54,7 @@ fn run_cargo_deb_command_on_example_dir() {
     assert!(md5sums.contains("b1946ac92492d2347c6235b4d2611184  var/lib/example/1.txt\n"));
     assert!(md5sums.contains("591785b794601e212b260e25925636fd  var/lib/example/2.txt\n"));
     assert!(md5sums.contains("1537684900f6b12358c88a612adf1049  var/lib/example/3.txt\n"));
-    assert!(md5sums.contains("e82262a2b9598001688d507f16ea3a61  usr/share/doc/example/copyright\n"));
+    assert!(md5sums.contains("4176f128e63dbe2f7ba37490bd0368db  usr/share/doc/example/copyright\n"));
 
     let ddir = TempDir::new("cargo-data-test").unwrap();
     assert!(Command::new("tar")
@@ -137,7 +137,7 @@ fn run_cargo_deb_command_on_example_dir_with_variant() {
     assert!(md5sums.contains("b1946ac92492d2347c6235b4d2611184  var/lib/example/1.txt\n"));
     assert!(md5sums.contains("591785b794601e212b260e25925636fd  var/lib/example/2.txt\n"));
     assert!(md5sums.contains("835a3c46f2330925774ebf780aa74241  var/lib/example/4.txt\n"));
-    assert!(md5sums.contains("9a6e2d2dd978ea60b29260416ee09dbc  usr/share/doc/example-debug/copyright\n"));
+    assert!(md5sums.contains("f4b165c5ea1f9ec1b87abd72845627fd  usr/share/doc/example-debug/copyright\n"));
 
     let ddir = TempDir::new("cargo-data-test").unwrap();
     assert!(Command::new("tar")


### PR DESCRIPTION
Change license string format for follow the debian standard format.

1. Not trim lines in a license file.
    Trimming spaces from head of line may break license file format (e.g. debian copyright format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/)

2. Add a .('dot') to the end of lines contains a space only
    > Those containing a single space followed by a single full stop character.
    https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-description