### PR TITLE
Add an optional metadata field to override the crate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For a more complete Debian package, you may also define a new table, `[package.m
 
 Everything is optional:
 
+- **name**: The name of the Debian package. If not present, the name of the crate is used.
 - **maintainer**: The person maintaining the Debian packaging. If not present, the first author is used.
 - **copyright**: To whom and when the copyright of the software is granted. If not present, the list of authors is used.
 - **license-file**: The location of the license and the amount of lines to skip at the top. If not present, package-level `license-file` is used.

--- a/src/control.rs
+++ b/src/control.rs
@@ -58,7 +58,7 @@ fn generate_control(archive: &mut Archive, options: &Config, listener: &mut dyn 
     let mut control: Vec<u8> = Vec::with_capacity(1024);
 
     // Write all of the lines required by the control file.
-    writeln!(&mut control, "Package: {}", options.name)?;
+    writeln!(&mut control, "Package: {}", options.deb_name)?;
     writeln!(&mut control, "Version: {}", options.version)?;
     writeln!(&mut control, "Architecture: {}", options.architecture)?;
     if let Some(ref repo) = options.repository {

--- a/src/debarchive.rs
+++ b/src/debarchive.rs
@@ -14,7 +14,7 @@ pub struct DebArchive {
 
 impl DebArchive {
     pub fn new(config: &Config) -> CDResult<Self> {
-        let out_filename = format!("{}_{}_{}.deb", config.name, config.version, config.architecture);
+        let out_filename = format!("{}_{}_{}.deb", config.deb_name, config.version, config.architecture);
         let prefix = config.deb_temp_dir();
         let out_abspath = config.deb_output_path(&out_filename);
         {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -189,6 +189,8 @@ pub struct Config {
     pub target_dir: PathBuf,
     /// The name of the project to build
     pub name: String,
+    /// The name to give the Debian package; usually the same as the Cargo project name
+    pub deb_name: String,
     /// The software license of the project (SPDX format).
     pub license: Option<String>,
     /// The location of the license file
@@ -350,7 +352,7 @@ impl Config {
         self.assets.resolved.push(Asset::new(
             AssetSource::Data(copyright_file),
             Path::new("usr/share/doc")
-                .join(&self.name)
+                .join(&self.deb_name)
                 .join("copyright"),
             0o644,
             false,
@@ -382,7 +384,7 @@ impl Config {
                 self.assets.resolved.push(Asset::new(
                     AssetSource::Data(changelog_file),
                     Path::new("usr/share/doc")
-                        .join(&self.name)
+                        .join(&self.deb_name)
                         .join("changelog.gz"),
                     0o644,
                     false,
@@ -533,6 +535,7 @@ impl Cargo {
             target: target.map(|t| t.to_string()),
             target_dir,
             name: self.package.name.clone(),
+            deb_name: deb.name.take().unwrap_or(self.package.name.clone()),
             license: self.package.license.take(),
             license_file,
             license_file_skip_lines,
@@ -711,6 +714,7 @@ struct CargoPackageMetadata {
 #[derive(Clone, Debug, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct CargoDeb {
+    pub name: Option<String>,
     pub maintainer: Option<String>,
     pub copyright: Option<String>,
     pub license_file: Option<Vec<String>>,
@@ -735,6 +739,7 @@ struct CargoDeb {
 impl CargoDeb {
     fn inherit_from(self, parent: CargoDeb) -> CargoDeb {
         CargoDeb {
+            name: self.name.or(parent.name),
             maintainer: self.maintainer.or(parent.maintainer),
             copyright: self.copyright.or(parent.copyright),
             license_file: self.license_file.or(parent.license_file),


### PR DESCRIPTION
We have a deployment scenario that requires all dpkg names to be of a certain format. I'm overcoming that for now by using some gross `sed` scripting to change the name field in `Cargo.toml` before running `cargo deb`, but this patch allows overriding the name in the Cargo metadata instead.