### PR TITLE
Make manifest module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ The library interface is experimental. See `main.rs` for usage.
 pub mod compress;
 pub mod control;
 pub mod data;
-mod manifest;
+pub mod manifest;
 mod dependencies;
 mod ok_or;
 mod wordsplit;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -68,7 +68,7 @@ impl AssetSource {
 }
 
 #[derive(Debug, Clone)]
-pub struct Assets {
+pub(crate) struct Assets {
     pub unresolved: Vec<UnresolvedAsset>,
     pub resolved: Vec<Asset>,
 }


### PR DESCRIPTION
I found myself wanting to explicitly control `Config.assets`. You can't do this without making the
various asset structs in the manifest module public. So this commit makes the module public
so all public symbols in that module can be usable by libraries.