### PR TITLE
Fix builds without LZMA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ addons:
 script:
   - cargo test --all
   - cargo install --path .
+  - cargo check --no-default-features
   - cd example && cargo deb

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -31,6 +31,6 @@ pub fn xz_or_gz(data: &[u8]) -> CDResult<Compressed> {
 }
 
 #[cfg(not(feature = "lzma"))]
-pub fn xz_or_gz(data: &[u8]) -> CDResult<Vec<u8>> {
-    gz(data, base_path).map(Compressed::Gz)
+pub fn xz_or_gz(data: &[u8]) -> CDResult<Compressed> {
+    gz(data).map(Compressed::Gz)
 }


### PR DESCRIPTION
A `--no-default-features` build currently does not compile due the GZip
code paths being broken. This tries to fix this and tries to prevent
this from happening again by at least checking those builds in the CI.