### PR TITLE
Replace - by ~ to keep version precedence

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -716,10 +716,12 @@ impl Cargo {
     }
 
     fn version_string(&self, revision: Option<String>) -> String {
+        let debianized_version = self.package.version.replace("-", "~");
+
         if let Some(revision) = revision {
-            format!("{}-{}", self.package.version, revision)
+            format!("{}-{}", debianized_version, revision)
         } else {
-            self.package.version.clone()
+            debianized_version
         }
     }
 }


### PR DESCRIPTION
This changes the default value of the version used for the deb package.

The current implementation uses the cargo version as a default, that is using
semantic versionning.

This is not ideal, as the precedence of versions using [semantic versionning][1]
is not the same as the one used in [debian][2].

This means that when using prerelease metadata from semver (for example
1.2.3-beta.4) the precedence of versions will not be respected by debian, and
version 1.2.3  will not bed installed over version 1.2.3-beta.4 which is
problematic as in semver precedence, they should.

A simple solution for that is discribed in this [comment on the semver
repository][3] and is what is commit implements

[1]: https://semver.org/#spec-item-11
[2]: https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
[3]: https://github.com/semver/semver/issues/97#issuecomment-19038801