### PR TITLE
Support templates file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Everything is optional:
         - If is argument ends with `/` it will be inferred that the target is the directory where the file will be copied.
         - Otherwise, it will be inferred that the source argument will be renamed when copied.
     3. The third argument is the permissions (octal string) to assign that file.
- - **maintainer-scripts** - directory containing `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
+ - **maintainer-scripts** - directory containing `templates`, `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
  - **conf-files** - [List of configuration files](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) that the package management system will not overwrite when the package is upgraded.
  - **changelog**: Path to Debian-formatted [changelog file](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog).
  - **features**: List of [Cargo features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) to use when building the package.

--- a/src/control.rs
+++ b/src/control.rs
@@ -25,7 +25,7 @@ pub fn generate_archive(options: &Config, time: u64, asset_hashes: HashMap<PathB
 /// Append all files that reside in the `maintainer_scripts` path to the archive
 fn generate_scripts(archive: &mut Archive, option: &Config) -> CDResult<()> {
     if let Some(ref maintainer_scripts) = option.maintainer_scripts {
-        for name in &["config", "preinst", "postinst", "prerm", "postrm"] {
+        for name in &["config", "preinst", "postinst", "prerm", "postrm", "templates"] {
             if let Ok(script) = fs::read(maintainer_scripts.join(name)) {
                 archive.file(name, &script, 0o755)?;
             }


### PR DESCRIPTION
I added `templates` file to maintainer-scripts.

If you create `templates` and `config` files, then you can configure the package at install-time.
- https://www.debian.org/doc/packaging-manuals/debconf_specification.html#id-1.7
- http://www.fifi.org/doc/debconf-doc/tutorial.html