### PR TITLE
Introduce option to omit --all from cargo build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,11 @@ pub fn remove_deb_temp_directory(options: &Config) {
 pub fn cargo_build(options: &Config, target: Option<&str>, other_flags: &[String], verbose: bool) -> CDResult<()> {
     let mut cmd = Command::new("cargo");
     cmd.current_dir(&options.manifest_dir);
-    cmd.arg("build").args(&["--release", "--all"]);
+    if options.build_whole_workspace {
+        cmd.arg("build").args(&["--release", "--all"]);
+    } else {
+        cmd.arg("build").args(&["--release"]);
+    }
 
     for flag in other_flags {
         cmd.arg(flag);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -296,6 +296,8 @@ pub struct Config {
     /// List of Cargo features to use during build
     pub features: Vec<String>,
     pub default_features: bool,
+    /// Pass --all to `cargo build`
+    pub build_whole_workspace: bool,
     /// Should the binary be stripped from debug symbols?
     pub strip: bool,
     /// Should the debug symbols be moved to a separate file included in the package? (implies `strip:true`)
@@ -653,6 +655,7 @@ impl Cargo {
             maintainer_scripts: deb.maintainer_scripts.map(PathBuf::from),
             features: deb.features.take().unwrap_or_default(),
             default_features: deb.default_features.unwrap_or(true),
+            build_whole_workspace: deb.build_whole_workspace.unwrap_or(true),
             separate_debug_symbols: deb.separate_debug_symbols.unwrap_or(false),
             strip: self.profile.as_ref().and_then(|p|p.release.as_ref())
                 .and_then(|r| r.debug.as_ref())
@@ -840,6 +843,7 @@ struct CargoDeb {
     pub maintainer_scripts: Option<String>,
     pub features: Option<Vec<String>>,
     pub default_features: Option<bool>,
+    pub build_whole_workspace: Option<bool>,
     pub separate_debug_symbols: Option<bool>,
     pub preserve_symlinks: Option<bool>,
     pub variants: Option<HashMap<String, CargoDeb>>,
@@ -870,6 +874,7 @@ impl CargoDeb {
             maintainer_scripts: self.maintainer_scripts.or(parent.maintainer_scripts),
             features: self.features.or(parent.features),
             default_features: self.default_features.or(parent.default_features),
+            build_whole_workspace: self.build_whole_workspace.or(parent.build_whole_workspace),
             separate_debug_symbols: self.separate_debug_symbols.or(parent.separate_debug_symbols),
             preserve_symlinks: self.preserve_symlinks.or(parent.preserve_symlinks),
             variants: self.variants.or(parent.variants),


### PR DESCRIPTION
One of my projects has a workspace setup but one of the crates only builds with nightly due to rocket. Right now `cargo deb` is always trying to build the rocket part as well and fails the build.

This option allows me to only build what I need:
```
[package.metadata.deb]
build-whole-workspace = false
```
Fixes #115