### PR TITLE
Fix debian architecture mapping for riscv64gc targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-deb"
-version = "1.24.0"
+version = "1.25.0"
 dependencies = [
  "ar 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_toml 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ There can be multiple variants of the metadata in one `Cargo.toml` file. `--vari
 
 ### Cross-compilation
 
-`cargo deb` supports a `--target` flag, which takes [Rust target triple](https://forge.rust-lang.org/platform-support.html). See `rustc --print target-list` for the list of supported values.
+`cargo deb` supports a `--target` flag, which takes [Rust target triple](https://forge.rust-lang.org/release/platform-support.html). See `rustc --print target-list` for the list of supported values.
 
 Cross-compilation can be run from any host, including macOS and Windows, provided that Debian-compatible linker and system libraries are available to Rust. The target has to be [installed for Rust](https://github.com/rust-lang-nursery/rustup.rs#cross-compilation) (e.g. `rustup target add i686-unknown-linux-gnu`) and has to be [installed for the host system (e.g. Debian)](https://wiki.debian.org/ToolChain/Cross) (e.g. `apt-get install libc6-dev-i386`). Note that Rust's and [Debian's architecture names](https://www.debian.org/ports/) are different.
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -945,6 +945,7 @@ pub(crate) fn get_arch(target: &str) -> &str {
         ("powerpc", "gnuspe") => "powerpcspe",
         ("powerpc64", _) => "ppc64",
         ("powerpc64le", _) => "ppc64el",
+        ("riscv64gc", _) => "riscv64",
         ("i586", _) | ("i686", _) | ("x86", _) => "i386",
         ("x86_64", "gnux32") => "x32",
         ("x86_64", _) => "amd64",


### PR DESCRIPTION
Build against rust targets like `riscv64gc-unknown-linux-gnu` should give debian package with `riscv64` as the architecture name, but currently it gives `riscv64gc`.

https://wiki.debian.org/Multiarch/Tuples

---

Also fix a broken link in README and update Cargo.lock to reflect the latest cargo-deb version.