### PR TITLE
Warn about missing license only if otherwise unset

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -679,7 +679,7 @@ impl Cargo {
         if self.package.description.is_none() {
             listener.warning("description field is missing in Cargo.toml".to_owned());
         }
-        if self.package.license.is_none() {
+        if self.package.license.is_none() && self.package.license_file.is_none() {
             listener.warning("license field is missing in Cargo.toml".to_owned());
         }
         if let Some(readme) = readme {


### PR DESCRIPTION
This commit adds a secondary check to the "missing license field" warning emitted by `check_config`, since not setting `license` in favour of `license_file` is a [documented valid option][1] when a project license is not an SPDX license expression.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields