### PR TITLE
Compress man pages.

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -81,9 +81,9 @@ pub fn compress_man_pages(options: &mut Config, listener: &dyn Listener) -> CDRe
         {
             listener.info(format!("Compressing '{}'", asset.source.path().unwrap().to_string_lossy()));
 
-            let content = asset.source.data().unwrap();
+            let content = asset.source.data()?;
             let mut compressed = Vec::with_capacity(content.len());
-            zopfli::compress(&Options::default(), &Format::Gzip, &content, &mut compressed).unwrap();
+            zopfli::compress(&Options::default(), &Format::Gzip, &content, &mut compressed)?;
             compressed.shrink_to_fit();
 
             new_assets.push(Asset::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,8 @@ fn process(
 
     options.resolve_assets()?;
 
+    crate::data::compress_man_pages(&mut options, listener)?;
+
     if (options.strip || separate_debug_symbols) && !no_strip {
         strip_binaries(&mut options, target, listener, separate_debug_symbols)?;
     }


### PR DESCRIPTION
As noted in #97 [Debian policy] stipulates that _"Manual pages should be installed compressed using gzip -9"_ and the Debian Lintian package checking tool raises [an error](https://lintian.debian.org/tags/manpage-not-compressed.html) if this is not the case.

This PR replaces assets that will be installed in "/usr/share/man/" with compressed ".gz" versions if the filename does not already end with ".gz". When verbose mode is activated it prints to the console at info level for each file that it compresses.