### PR TITLE
Add debhelper dh_installsystemd style support for systemd unit installation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,10 +41,12 @@ dependencies = [
  "cargo_toml 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 5.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -166,6 +168,14 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -337,9 +347,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rust-embed-impl 5.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed-utils 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed-utils 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scopeguard"
@@ -436,6 +483,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +505,14 @@ dependencies = [
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -502,6 +567,7 @@ dependencies = [
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
@@ -525,7 +591,11 @@ dependencies = [
 "checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 "checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+"checksum rust-embed 5.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "213acf1bc5a6dfcd70b62db1e9a7d06325c0e73439c312fcb8599d456d9686ee"
+"checksum rust-embed-impl 5.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7903c2cf599db8f310b392332f38367ca4acc84420fa1aee3536299f433c10d5"
+"checksum rust-embed-utils 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97655158074ccb2d2cfb1ccb4c956ef0f4054e43a2c1e71146d4991e6961e105"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
@@ -538,8 +608,10 @@ dependencies = [
 "checksum typed-arena 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
 "checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 "checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xz2 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ ar = "0.8"
 cargo_toml = "0.8"
 rayon = "1.0.3"
 regex = "1.3.1"
+itertools = "0.9.0"
+rust-embed = "5.6.0"
 
 [features]
 default = ["lzma"]

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ Everything is optional:
         - If is argument ends with `/` it will be inferred that the target is the directory where the file will be copied.
         - Otherwise, it will be inferred that the source argument will be renamed when copied.
     3. The third argument is the permissions (octal string) to assign that file.
- - **maintainer-scripts** - directory containing `templates`, `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
- - **conf-files** - [List of configuration files](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) that the package management system will not overwrite when the package is upgraded.
+ - **maintainer-scripts**: directory containing `templates`, `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
+ - **conf-files**: [List of configuration files](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) that the package management system will not overwrite when the package is upgraded.
  - **triggers-file**: Path to triggers control file for use by the dpkg trigger facility.
  - **changelog**: Path to Debian-formatted [changelog file](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog).
  - **features**: List of [Cargo features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) to use when building the package.
  - **default-features**: whether to use default crate features in addition to the `features` list (default `true`).
  - **separate-debug-symbols**: whether to keep debug symbols, but strip them from executables and save them in separate files (default `false`).
  - **preserve-symlinks**: Whether to preserve symlinks in the asset files (default `false`).
+ - **systemd-units**: Optional configuration settings for automated installation of systemd units.
 
 ### `[package.metadata.deb.systemd-units]` options
 
@@ -74,12 +75,12 @@ This works as follows:
 
 The exact behaviour can be tuned using the following options:
 
- - **unit-scripts** - directory containing zero or more [systemd unit files](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) (see below for matching rules) (default `maintainer-scripts`).
- - **unit-name** - only include systemd unit files for this unit (see below for matching rules).
- - **enable** - enable the systemd unit on package installation and disable it on package removal (default `true`).
- - **start** - start the systemd unit on package installation and stop it on package removal (default `true`).
- - **restart-after-upgrade** - if true, postpone systemd service restart until after upgrade is complete (+ = less downtime, - = can confuse some programs), otherwise stop the service before upgrade and start it again after upgrade (default `true`).
- - **stop-on-upgrade** - if true stop the systemd on package upgrade and removal, otherwise stop the sytemsd service only on package removal (default `true`).
+ - **unit-scripts**: Directory containing zero or more [systemd unit files](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) (see below for matching rules) (default `maintainer-scripts`).
+ - **unit-name**: Only include systemd unit files for this unit (see below for matching rules).
+ - **enable**: Enable the systemd unit on package installation and disable it on package removal (default `true`).
+ - **start**: Start the systemd unit on package installation and stop it on package removal (default `true`).
+ - **restart-after-upgrade**: If true, postpone systemd service restart until after upgrade is complete (+ = less downtime, - = can confuse some programs), otherwise stop the service before upgrade and start it again after upgrade (default `true`).
+ - **stop-on-upgrade**: If true stop the systemd on package upgrade and removal, otherwise stop the sytemsd service only on package removal (default `true`).
 
 Systemd unit file names must match one of the following patterns:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ No configuration is necessary to make a basic package from a Cargo project with 
 
 For a more complete Debian package, you may also define a new table, `[package.metadata.deb]` that contains `maintainer`, `copyright`, `license-file`, `changelog`, `depends`, `conflicts`, `breaks`, `replaces`, `provides`, `extended-description`/`extended-description-file`, `section`, `priority`, and `assets`.
 
+For a Debian package that includes one or more systemd unit files you may also wish to define a new (inline) table, `[package.metadata.deb.systemd-units]`, so that the unit files are automatically added as assets and the units are properly installed. See below for more details.
+
 ### `[package.metadata.deb]` options
 
 Everything is optional:
@@ -58,6 +60,51 @@ Everything is optional:
  - **default-features**: whether to use default crate features in addition to the `features` list (default `true`).
  - **separate-debug-symbols**: whether to keep debug symbols, but strip them from executables and save them in separate files (default `false`).
  - **preserve-symlinks**: Whether to preserve symlinks in the asset files (default `false`).
+
+### `[package.metadata.deb.systemd-units]` options
+
+When this table is present AND `maintainer-scripts` is specified, correct installation of systemd units will be handled automatically for you.
+
+This works as follows:
+1. Assets will be added for any matching systemd unit files found in the `unit-scripts` directory.
+2. Code blocks will be generated for enabling, disabling, starting, stopping, and restarting the corresponding systemd services, when the package is installed, updated, or removed.
+3. `maintainer-scripts` will be created using the generated code blocks.
+
+**Note:** `<maintainer-scripts>` **MUST** be set, even if it is an empty directory. If non-empty, any maintainer scripts present **MUST** contain the `#DEBHELPER#` token denoting the point at which generated code blocks should be inserted.
+
+The exact behaviour can be tuned using the following options:
+
+ - **unit-scripts** - directory containing zero or more [systemd unit files](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) (see below for matching rules) (default `maintainer-scripts`).
+ - **unit-name** - only include systemd unit files for this unit (see below for matching rules).
+ - **enable** - enable the systemd unit on package installation and disable it on package removal (default `true`).
+ - **start** - start the systemd unit on package installation and stop it on package removal (default `true`).
+ - **restart-after-upgrade** - if true, postpone systemd service restart until after upgrade is complete (+ = less downtime, - = can confuse some programs), otherwise stop the service before upgrade and start it again after upgrade (default `true`).
+ - **stop-on-upgrade** - if true stop the systemd on package upgrade and removal, otherwise stop the sytemsd service only on package removal (default `true`).
+
+Systemd unit file names must match one of the following patterns:
+
+ - `<package>.<unit>.<suffix>` - _only if `unit-name` is specified_
+ - `<package>.<unit>@.<suffix>` - _only if `unit-name` is specified_
+ - `<package>.<suffix>`
+ - `<pacakge>@.<suffix>`
+ - `<unit>.<suffix>` - _only if `unit-name` is specified_
+ - `<unit>@.<suffix>` - _only if `unit-name` is specified_
+
+User supplied `maintainer-scripts` file names must match one of the following patterns:
+
+ - `<package>.<unit>.<script>` - _only if `unit-name` is specified_
+ - `<package>.<script>`
+ - `<unit>.<script>` - _only if `unit-name` is specified_
+ - `<script>`
+
+Where `<script>` is one of: `preinst`, `postinst`, `prerm`, `postrm`.
+
+**NOTE:** When using the variant feature, `<package>` will actually be `<package>-<variant>` unless the variant name has been overridden using `name` in the variant specific metadata table. You can use this to supply variant specific unit files and maintainer scripts.
+
+See:
+ - The [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Description) for more details on unit naming.
+ - The [Debian Policy Manual](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html) for more information about maintainer scripts.
+ - A list of [code blocks](https://github.com/mmstick/cargo-deb/tree/579e10c89b060d=eec05ce8653f501c9eee3a0297/autoscripts) which may be inserted.
 
 ### Example of custom `Cargo.toml` additions
 

--- a/autoscripts/README.md
+++ b/autoscripts/README.md
@@ -1,0 +1,8 @@
+These debhelper autoscripts were taken from:
+https://git.launchpad.net/ubuntu/+source/debhelper/tree/autoscripts?h=applied/12.10ubuntu1
+
+WARNING: Each file MUST end with a line break, otherwise the scripts into which
+the fragments are inserted will not be valid shell scripts.
+
+To understand which scripts are invoked when, consult:
+https://www.debian.org/doc/debian-policy/ap-flowcharts.html

--- a/autoscripts/README.md
+++ b/autoscripts/README.md
@@ -1,8 +1,5 @@
 These debhelper autoscripts were taken from:
 https://git.launchpad.net/ubuntu/+source/debhelper/tree/autoscripts?h=applied/12.10ubuntu1
 
-WARNING: Each file MUST end with a line break, otherwise the scripts into which
-the fragments are inserted will not be valid shell scripts.
-
 To understand which scripts are invoked when, consult:
 https://www.debian.org/doc/debian-policy/ap-flowcharts.html

--- a/autoscripts/postinst-init-tmpfiles
+++ b/autoscripts/postinst-init-tmpfiles
@@ -1,0 +1,7 @@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# In case this system is running systemd, we need to ensure that all
+	# necessary tmpfiles (if any) are created before starting.
+	if [ -d /run/systemd/system ] ; then
+		systemd-tmpfiles --create #TMPFILES# >/dev/null || true
+	fi
+fi

--- a/autoscripts/postinst-systemd-dont-enable
+++ b/autoscripts/postinst-systemd-dont-enable
@@ -1,0 +1,15 @@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if deb-systemd-helper debian-installed #UNITFILE#; then
+		# This will only remove masks created by d-s-h on package removal.
+		deb-systemd-helper unmask #UNITFILE# >/dev/null || true
+
+		if deb-systemd-helper --quiet was-enabled #UNITFILE#; then
+			# Create new symlinks, if any.
+			deb-systemd-helper enable #UNITFILE# >/dev/null || true
+		fi
+	fi
+
+	# Update the statefile to add new symlinks (if any), which need to be cleaned
+	# up on purge. Also remove old symlinks.
+	deb-systemd-helper update-state #UNITFILE# >/dev/null || true
+fi

--- a/autoscripts/postinst-systemd-enable
+++ b/autoscripts/postinst-systemd-enable
@@ -1,0 +1,15 @@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# This will only remove masks created by d-s-h on package removal.
+	deb-systemd-helper unmask #UNITFILE# >/dev/null || true
+
+	# was-enabled defaults to true, so new installations run enable.
+	if deb-systemd-helper --quiet was-enabled #UNITFILE#; then
+		# Enables the unit on first installation, creates new
+		# symlinks on upgrades if the unit file has changed.
+		deb-systemd-helper enable #UNITFILE# >/dev/null || true
+	else
+		# Update the statefile to add new symlinks (if any), which need to be
+		# cleaned up on purge. Also remove old symlinks.
+		deb-systemd-helper update-state #UNITFILE# >/dev/null || true
+	fi
+fi

--- a/autoscripts/postinst-systemd-restart
+++ b/autoscripts/postinst-systemd-restart
@@ -1,0 +1,11 @@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		if [ -n "$2" ]; then
+			_dh_action=#RESTART_ACTION#
+		else
+			_dh_action=start
+		fi
+		deb-systemd-invoke $_dh_action #UNITFILES# >/dev/null || true
+	fi
+fi

--- a/autoscripts/postinst-systemd-restartnostart
+++ b/autoscripts/postinst-systemd-restartnostart
@@ -1,0 +1,8 @@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		if [ -n "$2" ]; then
+			deb-systemd-invoke #RESTART_ACTION# #UNITFILES# >/dev/null || true
+		fi
+	fi
+fi

--- a/autoscripts/postinst-systemd-start
+++ b/autoscripts/postinst-systemd-start
@@ -1,0 +1,6 @@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		deb-systemd-invoke start #UNITFILES# >/dev/null || true
+	fi
+fi

--- a/autoscripts/postrm-systemd
+++ b/autoscripts/postrm-systemd
@@ -1,0 +1,12 @@
+if [ "$1" = "remove" ]; then
+	if [ -x "/usr/bin/deb-systemd-helper" ]; then
+		deb-systemd-helper mask #UNITFILES# >/dev/null || true
+	fi
+fi
+
+if [ "$1" = "purge" ]; then
+	if [ -x "/usr/bin/deb-systemd-helper" ]; then
+		deb-systemd-helper purge #UNITFILES# >/dev/null || true
+		deb-systemd-helper unmask #UNITFILES# >/dev/null || true
+	fi
+fi

--- a/autoscripts/postrm-systemd-reload-only
+++ b/autoscripts/postrm-systemd-reload-only
@@ -1,0 +1,3 @@
+if [ -d /run/systemd/system ]; then
+	systemctl --system daemon-reload >/dev/null || true
+fi

--- a/autoscripts/prerm-systemd
+++ b/autoscripts/prerm-systemd
@@ -1,0 +1,3 @@
+if [ -d /run/systemd/system ]; then
+	deb-systemd-invoke stop #UNITFILES# >/dev/null || true
+fi

--- a/autoscripts/prerm-systemd-restart
+++ b/autoscripts/prerm-systemd-restart
@@ -1,0 +1,3 @@
+if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+	deb-systemd-invoke stop #UNITFILES# >/dev/null || true
+fi

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -1,0 +1,406 @@
+/// This module is a partial implementation of the Debian DebHelper command
+/// for properly installing systemd units as part of a .deb package install aka
+/// dh_installsystemd. Specifically this implementation is based on the Ubuntu
+/// version labelled 12.10ubuntu1 which is included in Ubuntu 20.04 LTS. For
+/// more details on the source version see the comments in dh_lib.rs.
+/// 
+/// # See also
+/// 
+/// Ubuntu 20.04 dh_installsystemd sources:
+/// https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1
+/// 
+/// Ubuntu 20.04 dh_installsystemd man page (online HTML version):
+/// http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html
+
+use itertools::Itertools; // for .next_tuple()
+
+use std::collections::{HashMap, HashSet};
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+use std::str;
+
+use crate::manifest::Asset;
+use crate::dh_lib::*;
+use crate::listener::Listener;
+use crate::util::*;
+
+// the map macro is defined in util.rs but gets exported at the crate root so
+// has to be imported like this:
+use crate::map;
+
+/// From man 1 dh_installsystemd on Ubuntu 20.04 LTS. See:
+///   http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html
+/// FILES
+///        debian/package.mount, debian/package.path, debian/package@.path,
+///        debian/package.service, debian/package@.service,
+///        debian/package.socket, debian/package@.socket, debian/package.target,
+///        debian/package@.target, debian/package.timer, debian/package@.timer
+///            If any of those files exists, they are installed into
+///            lib/systemd/system/ in the package build directory.
+/// 
+///        debian/package.tmpfile
+///            Only used in compat 12 or earlier.  In compat 13+, this file is
+///            handled by dh_installtmpfiles(1) instead.
+/// 
+///            If this exists, it is installed into usr/lib/tmpfiles.d/ in the
+///            package build directory. Note that the "tmpfiles.d" mechanism is
+///            currently only used by systemd.
+const LIB_SYSTEMD_SYSTEM_DIR: &str = "lib/systemd/system/";
+const USR_LIB_TMPFILES_D_DIR: &str = "usr/lib/tmpfiles.d/";
+const SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS: [(&str, &str, &str); 12] = [
+    ("",  "mount",   LIB_SYSTEMD_SYSTEM_DIR),
+    ("",  "path",    LIB_SYSTEMD_SYSTEM_DIR),
+    ("@", "path",    LIB_SYSTEMD_SYSTEM_DIR),
+    ("",  "service", LIB_SYSTEMD_SYSTEM_DIR),
+    ("@", "service", LIB_SYSTEMD_SYSTEM_DIR),
+    ("",  "socket",  LIB_SYSTEMD_SYSTEM_DIR),
+    ("@", "socket",  LIB_SYSTEMD_SYSTEM_DIR),
+    ("",  "target",  LIB_SYSTEMD_SYSTEM_DIR),
+    ("@", "target",  LIB_SYSTEMD_SYSTEM_DIR),
+    ("",  "timer",   LIB_SYSTEMD_SYSTEM_DIR),
+    ("@", "timer",   LIB_SYSTEMD_SYSTEM_DIR),
+    ("",  "tmpfile", USR_LIB_TMPFILES_D_DIR),
+];
+
+pub struct InstallRecipe {
+    pub path: PathBuf,
+    pub mode: u32
+}
+
+pub type PackageUnitFiles = HashMap<PathBuf, InstallRecipe>;
+
+/// From man 1 dh_installsystemd on Ubuntu 20.04 LTS. See:
+///   http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html
+/// --no-enable
+/// Disable the service(s) on purge, but do not enable them on install.
+/// 
+/// Note that this option does not affect whether the services are started.  Please
+/// remember to also use --no-start if the service should not be started.
+/// 
+/// --name=name
+/// This option controls several things.
+/// 
+/// It changes the name that dh_installsystemd uses when it looks for maintainer provided
+/// systemd unit files as listed in the "FILES" section.  As an example, dh_installsystemd
+/// --name foo will look for debian/package.foo.service instead of
+/// debian/package.service).  These unit files are installed as name.unit-extension (in
+/// the example, it would be installed as foo.service).
+/// 
+/// Furthermore, if no unit files are passed explicitly as command line arguments,
+/// dh_installsystemd will only act on unit files called name (rather than all unit files
+/// found in the package).
+/// 
+/// --restart-after-upgrade
+/// Do not stop the unit file until after the package upgrade has been completed.  This is
+/// the default behaviour in compat 10.
+/// 
+/// In earlier compat levels the default was to stop the unit file in the prerm, and start
+/// it again in the postinst.
+/// 
+/// This can be useful for daemons that should not have a possibly long downtime during
+/// upgrade. But you should make sure that the daemon will not get confused by the package
+/// being upgraded while it's running before using this option.
+/// 
+/// --no-restart-after-upgrade
+/// Undo a previous --restart-after-upgrade (or the default of compat 10).  If no other
+/// options are given, this will cause the service to be stopped in the prerm script and
+/// started again in the postinst script.
+/// 
+/// -r, --no-stop-on-upgrade, --no-restart-on-upgrade
+/// Do not stop service on upgrade.
+/// 
+/// --no-start
+/// Do not start the unit file after upgrades and after initial installation (the latter
+/// is only relevant for services without a corresponding init script).
+/// 
+/// Note that this option does not affect whether the services are enabled.  Please
+/// remember to also use --no-enable if the services should not be enabled.
+/// 
+/// unit file ...
+/// Only process and generate maintscripts for the installed unit files with the
+/// (base)name unit file.
+/// 
+/// Note: dh_installsystemd will still install unit files from debian/ but it will not
+/// generate any maintscripts for them unless they are explicitly listed in unit file ...
+#[derive(Default, Debug)]
+pub struct Options {
+    pub no_enable: bool,
+    pub no_start: bool,
+    pub restart_after_upgrade: bool,
+    pub no_stop_on_upgrade: bool,
+}
+
+/// Find installable systemd unit files for the specified debian package (and
+/// optional systemd unit name) in the given directory and return an install
+/// recipe for each file detailing the path at which the file should be
+/// installed and the mode (chmod) that the file should be given.
+/// 
+/// See:
+///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n264
+///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n198
+///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n957
+pub fn find_units(
+        dir: &PathBuf,
+        package: &str,
+        unit_name: Option<&str>)
+    -> PackageUnitFiles
+{
+    let mut installables = HashMap::new();
+
+    for (package_suffix, unit_type, install_dir) in SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS.iter() {
+        let package = &format!("{}{}", package, package_suffix);
+        if let Some(src_path) = pkgfile(dir, package, unit_type, unit_name) {
+            // .tmpfile files should be installed in a different directory and
+            // with a different extension. See:
+            //   https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html
+            let actual_suffix = match &unit_type[..] {
+                ".tmpfile" => ".conf",
+                _          => unit_type,
+            };
+
+            // Determine the file name that the unit file should be installed as
+            // which depends on whether or not a unit name was provided.
+            let install_filename = match unit_name {
+                Some(name) => format!("{}.{}", name, actual_suffix),
+                None       => format!("{}.{}", package, actual_suffix),
+            };
+
+            // Construct the full install path for this unit file.
+            let install_path = Path::new(install_dir).join(install_filename);
+
+            // Save the combination of source path, target path and target file
+            // mode for this unit file.
+            // eprintln!("[INFO] Identified installable at {:?}", src_path);
+            installables.insert(
+                src_path,
+                InstallRecipe {
+                    path: install_path,
+                    mode: 0o644,
+                }
+            );
+        }
+    }
+
+    installables
+}
+
+fn is_comment(s: &str) -> bool {
+    match s.chars().next() {
+        Some('#') => true,
+        Some(';') => true,
+        _         => false
+    }
+}
+
+fn unquote(s: &str) -> &str {
+    s.trim_matches(|c| c == '"' || c == '\'')
+}
+
+/// This function implements the primary logic of the Debian dh_installsystemd
+/// Perl script, which is to say it identifies systemd units being installed,
+/// inspects them and decides, based on the unit file and the configuration
+/// options provided, which DebHelper autoscripts to use to correctly install
+/// those units.
+/// 
+/// # Cargo Deb specific behaviour
+/// 
+/// Any `Asset`, whether identified by `find_units()` or added by the user
+/// manually in Cargo.toml, that will be installed into `LIB_SYSTEMD_SYSTEM_DIR`
+/// will be analysed.
+/// 
+/// User supplied maintainer scripts are copied into the provided temporary
+/// directory. A later call to `dh_lib::apply()` will merge the results of this
+/// function into those copies of the maintainer scripts, the users originals
+/// will be left untouched.
+/// 
+/// See:
+///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n288
+pub fn generate(
+    dir: &PathBuf,
+    package: &str,
+    assets: &std::vec::Vec<Asset>,
+    tmp_dir: &Path,
+    options: &Options,
+    listener: &mut dyn Listener)
+{
+    // copy maintainer scripts to the temporary directory.
+    for script_name in &["preinst", "postinst", "prerm", "postrm"] {
+        let src_path = dir.join(script_name);
+        if src_path.exists() {
+            let dst_path = tmp_dir.join(script_name);
+            listener.info(format!("Found user supplied maintainer script {}", script_name));
+            copy_file(&src_path, &dst_path).unwrap();
+        }
+    }
+
+    // add postinst code blocks to handle tmpfiles
+    // see: https://salsa.debian.org/debian/debhelper/-/blob/master/dh_installsystemd#L305
+    let tmp_file_names = assets
+        .iter()
+        .filter(|v| v.target_path.starts_with(USR_LIB_TMPFILES_D_DIR))
+        .map(|v | fname_from_path(v.source.path().unwrap()))
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    if !tmp_file_names.is_empty() {
+        autoscript(&tmp_dir, package, "postinst", "postinst-init-tmpfiles",
+            &map!{ "TMPFILES" => tmp_file_names}, listener);
+    }
+
+    // add postinst, prerm, and postrm code blocks to handle activation,
+    // deactivation, start and stopping of services when the package is
+    // installed, upgraded or removed.
+    // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n312
+
+    // skip template service files. Enabling, disabling, starting or stopping
+    // those services without specifying the instance is not useful.
+    let mut installed_non_template_units: HashSet<String> = HashSet::new();
+    installed_non_template_units.extend(assets
+        .iter()
+        .filter(|v| v.target_path.starts_with(LIB_SYSTEMD_SYSTEM_DIR))
+        .map(|v | fname_from_path(v.target_path.as_path()))
+        .filter(|fname| !fname.contains("@")));
+
+    let mut aliases = HashSet::new();
+    let mut enable_units = HashSet::new();
+    let mut start_units = HashSet::new();
+    let mut seen = HashSet::new();
+
+    // note: we do not support handling of services with a sysv-equivalent
+    // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n373
+    let mut units = installed_non_template_units;
+
+    // for all installed non-template units and any units they refer to via
+    // the 'Also=' key in their unit file, determine what if anything we need to
+    // arrange to be done for them in the maintainer scripts.
+    while !units.is_empty() {
+        // gather unit names mentioned in 'Also=' kv pairs in the unit files
+        let mut also_units = HashSet::<String>::new();
+
+        // for each unit that we have not yet processed
+        for unit in units.iter() {
+            listener.info(format!("Determining augmentations needed for systemd unit {}", unit));
+
+            // the unit has to be started
+            start_units.insert(unit.clone());
+
+            // get the unit file contents
+            let needle = Path::new(LIB_SYSTEMD_SYSTEM_DIR).join(unit);
+            let data = assets.iter()
+                .find(|&item| item.target_path == needle)
+                .unwrap()
+                .source
+                .data()
+                .unwrap();
+
+            let reader = data.into_owned();
+
+            // for every line in the file look for specific keys that we are
+            // interested in:
+            // From: https://www.freedesktop.org/software/systemd/man/systemd.syntax.html
+            //   "Each file is a plain text file divided into sections, with
+            //    configuration entries in the style key=value. Whitespace
+            //    immediately before or after the "=" is ignored. Empty lines
+            //    and lines starting with "#" or ";" are ignored which may be
+            //    used for commenting."
+            //   "Various settings are allowed to be specified more than
+            //    once"
+            // Key names _seem_ to be case sensitive. It's not explicitly
+            // stated in systemd.syntax.html above but this bug report seems
+            // to confirm it:
+            //   https://bugzilla.redhat.com/show_bug.cgi?id=846283
+            // We also strip the value of any surrounding quotes because
+            // that's what the actual dh_installsystemd code does:
+            //   https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n210
+            for line in reader.lines().map(|line| line.unwrap()).filter(|s| !is_comment(s)) {
+                let possible_kv_pair = line
+                    .splitn(2, '=')
+                    .map(|s| s.trim())
+                    .next_tuple();
+                if let Some((key, value)) = possible_kv_pair {
+                    let other_unit = unquote(value).to_string();
+                    match &key[..] {
+                        "Also" => {
+                            // The seen lookup prevents us from looping forever over
+                            // unit files that refer to each other. An actual
+                            // real-world example of such a loop is systemd's
+                            // systemd-readahead-drop.service, which contains
+                            // Also=systemd-readahead-collect.service, and that file
+                            // in turn contains Also=systemd-readahead-drop.service,
+                            // thus forming an endless loop.
+                            // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n340
+                            if seen.insert(other_unit.clone()) {
+                                also_units.insert(other_unit);
+                            }
+                        },
+                        "Alias" => {
+                            aliases.insert(other_unit);
+                        },
+                        _ => ()
+                    };
+                } else if line.starts_with("[Install]") {
+                    enable_units.insert(unit.clone());
+                }
+            }
+        }
+        units = also_units;
+    }
+
+    // update the maintainer scripts to enable units unless forbidden by the
+    // options passed to us.
+    // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n390
+    if !enable_units.is_empty() {
+        let snippet = match options.no_enable {
+            true  => "postinst-systemd-dont-enable",
+            false => "postinst-systemd-enable",
+        };
+        for unit in &enable_units {
+            autoscript(&tmp_dir, package, "postinst", snippet,
+                &map!{ "UNITFILE" => unit.clone()}, listener);
+        }
+        autoscript(&tmp_dir, package, "postrm", "postrm-systemd",
+            &map!{ "UNITFILES" => enable_units.join(" ")}, listener);
+    }
+
+    // update the maintainer scripts to start units, where the exact action to
+    // be taken is influenced by the options passed to us.
+    // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n398
+    if !start_units.is_empty() {
+        let mut replace = map!{ "UNITFILES" => start_units.join(" ")};
+
+        if options.no_stop_on_upgrade {
+            let snippet;
+            match options.no_start {
+                true => {
+                    snippet = "postinst-systemd-restartnostart";
+                    replace.insert("RESTART_ACTION", "try-restart".to_string());
+                },
+                false => {
+                    snippet = "postinst-systemd-restart";
+                    replace.insert("RESTART_ACTION", "restart".to_string());
+                }
+            };
+            autoscript(&tmp_dir, package, "postinst", snippet, &replace, listener);
+        } else {
+            if !options.no_start {
+                // (stop|start) service (before|after) upgrade
+                autoscript(&tmp_dir, package, "postinst", "postinst-systemd-start", &replace, listener);
+            }
+        }
+
+        if options.no_stop_on_upgrade || options.restart_after_upgrade {
+            // stop service only on remove
+			autoscript(&tmp_dir, package, "prerm", "prerm-systemd-restart", &replace, listener);
+        } else {
+            if !options.no_start {
+                // always stop service
+                autoscript(&tmp_dir, package, "prerm", "prerm-systemd", &replace, listener);
+            }
+        }
+
+        // Run this with "default" order so it is always after other service
+        // related autosnippets.
+		autoscript(&tmp_dir, package, "postrm", "postrm-systemd-reload-only", &replace, listener);
+    }
+}
+

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -37,11 +37,9 @@ use crate::map;
 ///        debian/package@.target, debian/package.timer, debian/package@.timer
 ///            If any of those files exists, they are installed into
 ///            lib/systemd/system/ in the package build directory.
-/// 
 ///        debian/package.tmpfile
 ///            Only used in compat 12 or earlier.  In compat 13+, this file is
 ///            handled by dh_installtmpfiles(1) instead.
-/// 
 ///            If this exists, it is installed into usr/lib/tmpfiles.d/ in the
 ///            package build directory. Note that the "tmpfiles.d" mechanism is
 ///            currently only used by systemd.
@@ -71,57 +69,57 @@ pub type PackageUnitFiles = HashMap<PathBuf, InstallRecipe>;
 
 /// From man 1 dh_installsystemd on Ubuntu 20.04 LTS. See:
 ///   http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html
-/// --no-enable
-/// Disable the service(s) on purge, but do not enable them on install.
-/// 
-/// Note that this option does not affect whether the services are started.  Please
-/// remember to also use --no-start if the service should not be started.
-/// 
-/// --name=name
-/// This option controls several things.
-/// 
-/// It changes the name that dh_installsystemd uses when it looks for maintainer provided
-/// systemd unit files as listed in the "FILES" section.  As an example, dh_installsystemd
-/// --name foo will look for debian/package.foo.service instead of
-/// debian/package.service).  These unit files are installed as name.unit-extension (in
-/// the example, it would be installed as foo.service).
-/// 
-/// Furthermore, if no unit files are passed explicitly as command line arguments,
-/// dh_installsystemd will only act on unit files called name (rather than all unit files
-/// found in the package).
-/// 
-/// --restart-after-upgrade
-/// Do not stop the unit file until after the package upgrade has been completed.  This is
-/// the default behaviour in compat 10.
-/// 
-/// In earlier compat levels the default was to stop the unit file in the prerm, and start
-/// it again in the postinst.
-/// 
-/// This can be useful for daemons that should not have a possibly long downtime during
-/// upgrade. But you should make sure that the daemon will not get confused by the package
-/// being upgraded while it's running before using this option.
-/// 
-/// --no-restart-after-upgrade
-/// Undo a previous --restart-after-upgrade (or the default of compat 10).  If no other
-/// options are given, this will cause the service to be stopped in the prerm script and
-/// started again in the postinst script.
-/// 
-/// -r, --no-stop-on-upgrade, --no-restart-on-upgrade
-/// Do not stop service on upgrade.
-/// 
-/// --no-start
-/// Do not start the unit file after upgrades and after initial installation (the latter
-/// is only relevant for services without a corresponding init script).
-/// 
-/// Note that this option does not affect whether the services are enabled.  Please
-/// remember to also use --no-enable if the services should not be enabled.
-/// 
-/// unit file ...
-/// Only process and generate maintscripts for the installed unit files with the
-/// (base)name unit file.
-/// 
-/// Note: dh_installsystemd will still install unit files from debian/ but it will not
-/// generate any maintscripts for them unless they are explicitly listed in unit file ...
+/// > --no-enable
+/// > Disable the service(s) on purge, but do not enable them on install.
+/// > 
+/// > Note that this option does not affect whether the services are started.  Please
+/// > remember to also use --no-start if the service should not be started.
+/// > 
+/// > --name=name
+/// > This option controls several things.
+/// > 
+/// > It changes the name that dh_installsystemd uses when it looks for maintainer provided
+/// > systemd unit files as listed in the "FILES" section.  As an example, dh_installsystemd
+/// > --name foo will look for debian/package.foo.service instead of
+/// > debian/package.service).  These unit files are installed as name.unit-extension (in
+/// > the example, it would be installed as foo.service).
+/// > 
+/// > Furthermore, if no unit files are passed explicitly as command line arguments,
+/// > dh_installsystemd will only act on unit files called name (rather than all unit files
+/// > found in the package).
+/// > 
+/// > --restart-after-upgrade
+/// > Do not stop the unit file until after the package upgrade has been completed.  This is
+/// > the default behaviour in compat 10.
+/// > 
+/// > In earlier compat levels the default was to stop the unit file in the prerm, and start
+/// > it again in the postinst.
+/// > 
+/// > This can be useful for daemons that should not have a possibly long downtime during
+/// > upgrade. But you should make sure that the daemon will not get confused by the package
+/// > being upgraded while it's running before using this option.
+/// > 
+/// > --no-restart-after-upgrade
+/// > Undo a previous --restart-after-upgrade (or the default of compat 10).  If no other
+/// > options are given, this will cause the service to be stopped in the prerm script and
+/// > started again in the postinst script.
+/// > 
+/// > -r, --no-stop-on-upgrade, --no-restart-on-upgrade
+/// > Do not stop service on upgrade.
+/// > 
+/// > --no-start
+/// > Do not start the unit file after upgrades and after initial installation (the latter
+/// > is only relevant for services without a corresponding init script).
+/// > 
+/// > Note that this option does not affect whether the services are enabled.  Please
+/// > remember to also use --no-enable if the services should not be enabled.
+/// > 
+/// > unit file ...
+/// > Only process and generate maintscripts for the installed unit files with the
+/// > (base)name unit file.
+/// > 
+/// > Note: dh_installsystemd will still install unit files from debian/ but it will not
+/// > generate any maintscripts for them unless they are explicitly listed in unit file ...
 #[derive(Default, Debug)]
 pub struct Options {
     pub no_enable: bool,

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -56,7 +56,7 @@ struct Autoscripts;
 /// # References
 ///
 /// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n957
-pub(crate) fn pkgfile(dir: &PathBuf, package: &str, filename: &str, unit_name: Option<&str>)
+pub(crate) fn pkgfile(dir: &Path, package: &str, filename: &str, unit_name: Option<&str>)
      -> Option<PathBuf>
 {
     // From man 1 dh_installsystemd on Ubuntu 20.04 LTS. See:
@@ -188,7 +188,7 @@ fn autoscript_sed(
 /// # References
 ///
 /// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n2161
-fn debhelper_script_subst(tmp_dir: &PathBuf, package: &str, script: &str, unit_name: Option<&str>,
+fn debhelper_script_subst(tmp_dir: &Path, package: &str, script: &str, unit_name: Option<&str>,
     listener: &mut dyn Listener)
 {
     let user_file = pkgfile(tmp_dir, package, script, unit_name);
@@ -230,7 +230,7 @@ fn debhelper_script_subst(tmp_dir: &PathBuf, package: &str, script: &str, unit_n
 /// collected in the temp directory with the originals supplied by the user.
 /// 
 /// See: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installdeb?h=applied/12.10ubuntu1#n300
-pub(crate) fn apply(tmp_dir: &PathBuf, package: &str, unit_name: Option<&str>,
+pub(crate) fn apply(tmp_dir: &Path, package: &str, unit_name: Option<&str>,
     listener: &mut dyn Listener)
 {
     for script in &["postinst", "preinst", "prerm", "postrm"] {

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -172,6 +172,11 @@ fn autoscript_sed(
     for (from, to) in replacements {
         snippet = snippet.replace(&format!("#{}#", from), to);
     }
+
+    if !snippet.ends_with('\n') {
+        snippet.push('\n');
+    }
+
     snippet
 }
 

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -1,0 +1,241 @@
+/// This module is a partial implementation of the Debian DebHelper core library
+/// aka dh_lib. Specifically this implementation is based on the Ubuntu version
+/// labelled 12.10ubuntu1 which is included in Ubuntu 20.04 LTS. I believe 12 is
+/// a reference to Debian 12 "Bookworm", i.e. Ubuntu uses future Debian sources
+/// and is also referred to as compat level 12 by debhelper documentation. Only
+/// functionality that was needed to properly script installation of systemd
+/// units, i.e. that used by the debhelper dh_instalsystemd command or rather
+/// our dh_installsystemd.rs implementation of it, is included here.
+/// 
+/// # See also
+/// 
+/// Ubuntu 20.04 dh_lib sources:
+/// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1
+/// 
+/// Ubuntu 20.04 dh_installsystemd man page (online HTML version):
+/// http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installdeb.1.html
+
+use rust_embed::RustEmbed;
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+
+use crate::listener::Listener;
+
+/// DebHelper autoscripts are embedded in the Rust library binary. For more
+/// information about the source of the scripts see `autoscripts/README.md`.
+#[derive(RustEmbed)]
+#[folder = "autoscripts/"]
+struct Autoscripts;
+
+/// Find a file in the given directory that best match the given package,
+/// filename and (optional) unit name. Enables callers to use the most specific
+/// match while also falling back to a less specific match (e.g. a file to be
+/// used as a default) when more specific matches are not available.
+/// 
+/// Returns one of the following, in order of most preferred first:
+/// 
+///   - Some("<dir>/<package>.<unit_name>.<filename>")
+///   - Some("<dir>/<package>.<filename>")
+///   - Some("<dir>/<unit_name>.<filename>")
+///   - Some("<dir>/<filename>")
+///   - None
+/// 
+/// <filename> is either a systemd unit type such as `service` or `socket`, or a
+/// maintainer script name such as `postinst`.
+///
+/// # Known limitations
+/// 
+/// The pkgfile() subroutine in the actual dh_installsystemd code is capable of
+/// matching architecture and O/S specific unit files, but this implementation
+/// does not support architecture or O/S specific unit files.
+/// 
+/// # References
+///
+/// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n957
+pub(crate) fn pkgfile(dir: &PathBuf, package: &str, filename: &str, unit_name: Option<&str>)
+     -> Option<PathBuf>
+{
+    // From man 1 dh_installsystemd on Ubuntu 20.04 LTS. See:
+    //   http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html
+    // --name=name
+    //     ...
+    //     It changes the name that dh_installsystemd uses when it looks for
+    //     maintainer provided systemd unit files as listed in the "FILES"
+    //     section.  As an example, dh_installsystemd --name foo will look for
+    //     debian/package.foo.service instead of debian/package.service).  These
+    //     unit files are installed as name.unit-extension (in the example, it
+    //     would be installed as foo.service).
+    //     ...
+    let named_filename = if let Some(str) = unit_name {
+        format!("{}.{}", str, filename)
+    } else {
+        filename.to_owned()
+    };
+
+    let mut paths_to_try = Vec::new();
+    paths_to_try.push(dir.join(format!("{}.{}", package, named_filename)));
+    paths_to_try.push(dir.join(format!("{}.{}", package, filename)));
+    paths_to_try.push(dir.join(named_filename.clone()));
+    paths_to_try.push(dir.join(filename.clone()));
+
+    for path_to_try in paths_to_try {
+        if path_to_try.is_file() {
+            return Some(path_to_try);
+        }
+    }
+
+    None
+}
+
+/// Build up one or more shell script fragments for a given maintainer script
+/// for a debian package in preparation for writing them into or as complete
+/// maintainer scripts in `apply()`, pulling fragments from a "library" of
+/// so-called "autoscripts".
+/// 
+/// Takes a map of values to search and replace in the selected "autoscript"
+/// fragment such as a systemd unit name placeholder and value.
+/// 
+/// # Cargo Deb specific behaviour
+/// 
+/// The autoscripts are sourced from within the binary via the rust_embed crate.
+/// 
+/// # Known limitations
+/// 
+/// Arbitrary sed command based file editing is not supported.
+/// 
+/// # References
+///
+/// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n1135
+pub(crate) fn autoscript(
+    tmp_dir: &Path,
+    package: &str,
+    script: &str,
+    snippet_filename: &str,
+    replacements: &HashMap<&str, String>,
+    listener: &mut dyn Listener)
+{
+    let bin_name = std::env::current_exe().unwrap();
+    let bin_name = bin_name.file_name().unwrap();
+    let bin_name = bin_name.to_str().unwrap();
+    let outfile = tmp_dir.join(format!("{}.{}.debhelper", package, script));
+
+    listener.info(format!("Maintainer script {} will be augmented with autoscript {}", &script, snippet_filename));
+
+    if outfile.exists() && (script == "postrm" || script == "prerm") {
+        if !replacements.is_empty() {
+            // prepend new text to existing file
+            let mut new_text = String::new();
+            new_text.push_str(&format!("# Automatically added by {}\n", bin_name));
+            new_text.push_str(&autoscript_sed(snippet_filename, replacements));
+            new_text.push_str("# End automatically added section\n");
+            new_text.push_str(&std::fs::read_to_string(&outfile).unwrap());
+            let mut file = File::create(&outfile).unwrap(); // deletes the original, if any
+            file.write_all(&new_text.into_bytes()).unwrap();
+        } else {
+            // We don't support sed commands yet.
+            unimplemented!();
+        }
+    } else if !replacements.is_empty() {
+        let mut new_text = String::new();
+        new_text.push_str(&format!("# Automatically added by {:?}\n", bin_name));
+        new_text.push_str(&autoscript_sed(snippet_filename, replacements));
+        new_text.push_str("# End automatically added section\n");
+        let mut file = if !outfile.exists() {
+            File::create(&outfile).unwrap()
+        } else {
+            OpenOptions::new().append(true).open(&outfile).unwrap()
+        };
+        file.write_all(&new_text.into_bytes()).unwrap();
+    } else {
+        // We don't support sed commands yet.
+        unimplemented!();
+    }
+}
+
+/// Search and replace a collection of key => value pairs in the given file and
+/// return the resulting text as a String.
+/// 
+/// # References
+///
+/// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n1203
+fn autoscript_sed(
+    snippet_filename: &str,
+    replacements: &HashMap<&str, String>)
+        -> String
+{
+    let snippet = Autoscripts::get(snippet_filename).unwrap();
+    let mut snippet = String::from(std::str::from_utf8(snippet.as_ref()).unwrap());
+    for (from, to) in replacements {
+        snippet = snippet.replace(&format!("#{}#", from), to);
+    }
+    String::from(snippet)
+}
+
+/// Copy the merged autoscript fragments to the final maintainer script, either
+/// at the point where the user placed a #DEBHELPER# token to indicate where
+/// they should be inserted, or by adding a shebang header to make the fragments
+/// into a complete shell script.
+/// 
+/// # Known limitations
+/// 
+/// We only replace #DEBHELPER#. Is that enough? See:
+///   https://www.man7.org/linux/man-pages/man1/dh_installdeb.1.html#SUBSTITUTION_IN_MAINTAINER_SCRIPTS
+///
+/// # References
+///
+/// https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n2161
+fn debhelper_script_subst(tmp_dir: &PathBuf, package: &str, script: &str, unit_name: Option<&str>,
+    listener: &mut dyn Listener)
+{
+    let user_file = pkgfile(tmp_dir, package, script, unit_name);
+    let generated_file = tmp_dir.join(format!("{}.{}.debhelper", package, script));
+    let out_file = tmp_dir.join(script);
+
+    if user_file.is_some() {
+        listener.info(format!("Augmenting maintainer script {}", script));
+
+        // merge the generated scripts if they exist into the user script
+        // if no generated script exists, we still need to remove #DEBHELPER# if
+        // present otherwise the script will be syntactically invalid
+        let generated_text = if generated_file.exists() {
+            std::fs::read_to_string(generated_file).unwrap()
+        } else {
+            String::from("")
+        };
+        let user_text = std::fs::read_to_string(user_file.clone().unwrap()).unwrap();
+        let new_text = user_text.replace("#DEBHELPER#", &generated_text);
+        if new_text == user_text {
+            panic!("#DEBHELPER# token not found in maintainer script {:?}",
+                user_file.unwrap().strip_prefix(tmp_dir).unwrap());
+        }
+        let mut file = File::create(out_file).unwrap(); // deletes the original, if any
+        file.write_all(&new_text.into_bytes()).unwrap();
+    } else if generated_file.exists() {
+        listener.info(format!("Generating maintainer script {}", script));
+        // give it a shebang header and rename it
+        let mut new_text = String::new();
+        new_text.push_str("#!/bin/sh\n");
+        new_text.push_str("set -e\n");
+        new_text.push_str(&std::fs::read_to_string(&generated_file).unwrap());
+        let mut file = File::create(out_file).unwrap(); // deletes the original, if any
+        file.write_all(&new_text.into_bytes()).unwrap();
+    }
+}
+
+/// Generate final maintainer scripts by merging the autoscripts that have been
+/// collected in the temp directory with the originals supplied by the user.
+/// 
+/// See: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installdeb?h=applied/12.10ubuntu1#n300
+pub(crate) fn apply(tmp_dir: &PathBuf, package: &str, unit_name: Option<&str>,
+    listener: &mut dyn Listener)
+{
+    for script in &["postinst", "preinst", "prerm", "postrm"] {
+        // note: we don't support custom defines thus we don't have the a last
+        // 'package_subst' argument to debhelper_script_subst().
+        debhelper_script_subst(tmp_dir, package, script, unit_name, listener);
+    }
+}

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -172,7 +172,7 @@ fn autoscript_sed(
     for (from, to) in replacements {
         snippet = snippet.replace(&format!("#{}#", from), to);
     }
-    String::from(snippet)
+    snippet
 }
 
 /// Copy the merged autoscript fragments to the final maintainer script, either

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ mod ok_or;
 mod pathbytes;
 mod tararchive;
 mod wordsplit;
+mod dh_installsystemd;
+mod dh_lib;
+mod util;
 
 use crate::listener::Listener;
 use std::env;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -96,8 +96,8 @@ pub(crate) struct SystemdUnitsConfig {
 impl From<&SystemdUnitsConfig> for dh_installsystemd::Options {
     fn from(config: &SystemdUnitsConfig) -> Self {
         Self {
-            no_enable: !config.enable.unwrap_or(false),
-            no_start: !config.start.unwrap_or(false),
+            no_enable: !config.enable.unwrap_or(true),
+            no_start: !config.start.unwrap_or(true),
             restart_after_upgrade: config.restart_after_upgrade.unwrap_or(true),
             no_stop_on_upgrade: !config.stop_on_upgrade.unwrap_or(true),
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,12 +16,6 @@ pub(crate) fn copy_file(from: &Path, to: &Path) -> std::io::Result<u64> {
 /// # Provenance
 /// 
 /// From: https://stackoverflow.com/a/27582993
-/// 
-/// # Usage
-/// 
-/// ```
-/// let names = map!{ 1 => "one", 2 => "two" };
-/// ```
 #[macro_export]
 macro_rules! map(
     { $($key:expr => $value:expr),+ } => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,66 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Get the filename from a path. Intended to be erplaced when testing.
+pub(crate) fn fname_from_path(path: &Path) -> String {
+    path.file_name().unwrap().to_string_lossy().to_string()
+}
+
+/// Copy a file from `from` to `to`. Intended to be replaced when testing.
+pub(crate) fn copy_file(from: &Path, to: &Path) -> std::io::Result<u64> {
+    std::fs::copy(&from, &to)
+}
+
+/// Create a HashMap from one or more key => value pairs in a single statement.
+/// 
+/// # Provenance
+/// 
+/// From: https://stackoverflow.com/a/27582993
+/// 
+/// # Usage
+/// 
+/// ```
+/// let names = map!{ 1 => "one", 2 => "two" };
+/// ```
+#[macro_export]
+macro_rules! map(
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+     };
+);
+
+/// A trait for returning a String containing items separated by the given
+/// separator.
+pub(crate) trait MyJoin {
+    fn join(&self, sep: &str) -> String;
+}
+
+/// Returns a String containing the hash set items joined together by the given
+/// separator.
+impl MyJoin for HashSet<String> {
+    fn join(&self, sep: &str) -> String {
+        let mut v = Vec::<&str>::new();
+        for item in self.iter() {
+            v.push(item.as_str());
+        }
+        v.join(sep)
+    }
+}
+
+/// Return Some(path) to the first directory in the `search_dirs` array that
+/// contains an immediate child file with name `filename`, if found, else None.
+pub(crate) fn find_first(search_dirs: &[PathBuf], filename: &str) -> Option<PathBuf> {
+    search_dirs.iter().find_map(|dir| {
+        let abs_path = dir.join(filename);
+        match abs_path.exists() {
+            true => Some(abs_path),
+            false => None
+        }
+    })
+}


### PR DESCRIPTION
This PR contains a Rust implementation of the Debian debhelper dh_installsystemd functionality which augments or generates maintainer scripts such that when  `systemd_units` is configured, shell script fragments _"for enabling, disabling, starting, stopping and restarting systemd unit files"_ (quoting [man 1 dh_installsystemd](http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html)) will replace the `#DEBHELPER#` token in the provided maintainer scripts (or provide the entire script if missing).

The README.md has now been updated on how to use this functionality.

Note: I wasn't aware of the discussion in https://github.com/mmstick/cargo-deb/issues/106 when I wrote this.

There are no tests included in this PR yet. I have some tests I started writing but they are out of date for the code as it is now. I thought it best to first get some feedback and no doubt the code can be improved with review.

I am using this to improve the .deb archives I have created as part of the [NLnet Labs Krill project](https://www.nlnetlabs.nl/projects/rpki/krill/). In that project I have 5 variants and prior to this PR [require almost identical asset blocks in each variant](https://github.com/NLnetLabs/krill/blob/master/Cargo.toml#L61) in order to select different systemd unit files by target O/S version, and hand coded the maintainer scripts.

With this PR I fix issues in my maintainer scripts by adding systemd unit management shell script fragments exactly how Debian suggests it should be done and also reduce duplication in my Cargo.toml as the variant is used to select the right unit file and add it as an asset automatically.

By default systemd unit files are looked for in the maintainer scripts directory. This can be overriden by providing a units directory to the `systemd_units` TOML (inline) table. Here's my current `systemd_units` configuration:

```

[package.metadata.deb.systemd-units]
unit-name = "krill"
enable = false
start = true
restart-after-upgrade = false
stop-on-upgrade = true
```

The enable, start, etc options match the options that can be passed to `dh_installsystemd`.

Example output when run with `-v`:

```
$ cargo-deb --variant ubuntu1804 --deb-version 0.8.0~rc1-1bionic -v
info: Stripped '/home/ximon/Documents/code/krill/krill-master/target/release/krill'
info: Stripped '/home/ximon/Documents/code/krill/krill-master/target/release/krillc'
info: - -> usr/share/doc/krill/copyright
info: /home/ximon/Documents/code/krill/krill-master/debian/krill-ubuntu1804.krill.service -> lib/systemd/system/krill.service
info: /home/ximon/Documents/code/krill/krill-master/target/release/krill -> usr/bin/krill
info: /home/ximon/Documents/code/krill/krill-master/target/release/krillc -> usr/bin/krillc
info: /home/ximon/Documents/code/krill/krill-master/defaults/krill.conf -> usr/share/doc/krill/krill.conf
info: /home/ximon/Documents/code/krill/krill-master/doc/krill.1 -> usr/share/man/man1/krill.1
info: /home/ximon/Documents/code/krill/krill-master/doc/krillc.1 -> usr/share/man/man1/krillc.1
info: Found user supplied maintainer script preinst
info: Found user supplied maintainer script postinst
info: Found user supplied maintainer script postrm
info: Determining augmentations needed for systemd unit krill.service
info: Maintainer script postinst will be augmented with autoscript postinst-systemd-dont-enable
info: Maintainer script postrm will be augmented with autoscript postrm-systemd
info: Maintainer script postinst will be augmented with autoscript postinst-systemd-start
info: Maintainer script prerm will be augmented with autoscript prerm-systemd
info: Maintainer script postrm will be augmented with autoscript postrm-systemd-reload-only
info: Augmenting maintainer script postinst
info: Augmenting maintainer script preinst
info: Generating maintainer script prerm
info: Augmenting maintainer script postrm
info: Archiving target/debian/krill-ubuntu1804/systemd/preinst
info: Archiving target/debian/krill-ubuntu1804/systemd/postinst
info: Archiving target/debian/krill-ubuntu1804/systemd/prerm
info: Archiving target/debian/krill-ubuntu1804/systemd/postrm
info: compressed/original ratio 7558272/29141504 (25%)
/home/ximon/Documents/code/krill/krill-master/target/debian/krill_0.8.0~rc1-1bionic_amd64.deb
```

Feedback very appreciated!