### PR TITLE
Correct changelog naming per Debian policy.

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -455,7 +455,7 @@ impl Config {
                     AssetSource::Data(changelog_file),
                     Path::new("usr/share/doc")
                         .join(&self.deb_name)
-                        .join("changelog.gz"),
+                        .join("changelog.Debian.gz"),
                     0o644,
                     false,
                 ));

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -50,7 +50,7 @@ fn run_cargo_deb_command_on_example_dir() {
 
     let md5sums = fs::read_to_string(cdir.path().join("md5sums")).unwrap();
     assert!(md5sums.contains(" usr/bin/example\n"));
-    assert!(md5sums.contains(" usr/share/doc/example/changelog.gz\n"));
+    assert!(md5sums.contains(" usr/share/doc/example/changelog.Debian.gz\n"));
     assert!(md5sums.contains("b1946ac92492d2347c6235b4d2611184  var/lib/example/1.txt\n"));
     assert!(md5sums.contains("591785b794601e212b260e25925636fd  var/lib/example/2.txt\n"));
     assert!(md5sums.contains("1537684900f6b12358c88a612adf1049  var/lib/example/3.txt\n"));
@@ -67,12 +67,12 @@ fn run_cargo_deb_command_on_example_dir() {
     assert!(ddir.path().join("var/lib/example/2.txt").exists());
     assert!(ddir.path().join("var/lib/example/3.txt").exists());
     assert!(ddir.path().join("usr/share/doc/example/copyright").exists());
-    assert!(ddir.path().join("usr/share/doc/example/changelog.gz").exists());
+    assert!(ddir.path().join("usr/share/doc/example/changelog.Debian.gz").exists());
     assert!(ddir.path().join("usr/bin/example").exists());
-    // changelog.gz starts with the gzip magic
+    // changelog.Debian.gz starts with the gzip magic
     assert_eq!(
         &[0x1F, 0x8B],
-        &fs::read(ddir.path().join("usr/share/doc/example/changelog.gz")).unwrap()[..2]
+        &fs::read(ddir.path().join("usr/share/doc/example/changelog.Debian.gz")).unwrap()[..2]
     );
 }
 
@@ -133,7 +133,7 @@ fn run_cargo_deb_command_on_example_dir_with_variant() {
 
     let md5sums = fs::read_to_string(cdir.path().join("md5sums")).unwrap();
     assert!(md5sums.contains(" usr/bin/example\n"));
-    assert!(md5sums.contains(" usr/share/doc/example-debug/changelog.gz\n"));
+    assert!(md5sums.contains(" usr/share/doc/example-debug/changelog.Debian.gz\n"));
     assert!(md5sums.contains("b1946ac92492d2347c6235b4d2611184  var/lib/example/1.txt\n"));
     assert!(md5sums.contains("591785b794601e212b260e25925636fd  var/lib/example/2.txt\n"));
     assert!(md5sums.contains("835a3c46f2330925774ebf780aa74241  var/lib/example/4.txt\n"));
@@ -150,7 +150,7 @@ fn run_cargo_deb_command_on_example_dir_with_variant() {
     assert!(ddir.path().join("var/lib/example/2.txt").exists());
     assert!(ddir.path().join("var/lib/example/4.txt").exists());
     assert!(ddir.path().join("usr/share/doc/example-debug/copyright").exists());
-    assert!(ddir.path().join("usr/share/doc/example-debug/changelog.gz").exists());
+    assert!(ddir.path().join("usr/share/doc/example-debug/changelog.Debian.gz").exists());
     assert!(ddir.path().join("usr/bin/example").exists());
 }
 
@@ -206,7 +206,7 @@ fn run_cargo_deb_command_on_example_dir_with_version() {
 
     let md5sums = fs::read_to_string(cdir.path().join("md5sums")).unwrap();
     assert!(md5sums.contains(" usr/bin/example\n"));
-    assert!(md5sums.contains(" usr/share/doc/example/changelog.gz\n"));
+    assert!(md5sums.contains(" usr/share/doc/example/changelog.Debian.gz\n"));
     assert!(md5sums.contains("b1946ac92492d2347c6235b4d2611184  var/lib/example/1.txt\n"));
     assert!(md5sums.contains("591785b794601e212b260e25925636fd  var/lib/example/2.txt\n"));
     assert!(md5sums.contains("1537684900f6b12358c88a612adf1049  var/lib/example/3.txt\n"));
@@ -223,11 +223,11 @@ fn run_cargo_deb_command_on_example_dir_with_version() {
     assert!(ddir.path().join("var/lib/example/2.txt").exists());
     assert!(ddir.path().join("var/lib/example/3.txt").exists());
     assert!(ddir.path().join("usr/share/doc/example/copyright").exists());
-    assert!(ddir.path().join("usr/share/doc/example/changelog.gz").exists());
+    assert!(ddir.path().join("usr/share/doc/example/changelog.Debian.gz").exists());
     assert!(ddir.path().join("usr/bin/example").exists());
-    // changelog.gz starts with the gzip magic
+    // changelog.Debian.gz starts with the gzip magic
     assert_eq!(
         &[0x1F, 0x8B],
-        &fs::read(ddir.path().join("usr/share/doc/example/changelog.gz")).unwrap()[..2]
+        &fs::read(ddir.path().join("usr/share/doc/example/changelog.Debian.gz")).unwrap()[..2]
     );
 }


### PR DESCRIPTION
According to [Lintian](https://lintian.debian.org/tags/debian-changelog-file-missing-or-wrong-name.html):
> Each Debian package (which provides a /usr/share/doc/pkg directory) must install a Debian changelog file in /usr/share/doc/pkg/changelog.Debian.gz
> 
> A common error is to name the Debian changelog like an upstream changelog (/usr/share/doc/pkg/changelog.gz); therefore, > Lintian will apply further checks to such a file if it exists even after issuing this error.
> 
> Refer to Debian Policy Manual section 12.7 (Changelog files and release notes) for details.

The Debian Policy Manual says:

> Packages that are not Debian-native must contain a compressed copy of the debian/changelog file from the Debian source tree in /usr/share/doc/package with the name **changelog.Debian.gz**.
> 
> If an upstream release notes file is available, containing a summary of changes between upstream releases intended for end users of the package and often called NEWS, it should be accessible as /usr/share/doc/package/NEWS.gz. An older practice of installing the upstream release notes as /usr/share/doc/package/changelog.gz is **permitted but deprecated**.

Without this naming change Lintian considers the deprecated name to be [an error](https://github.com/NLnetLabs/krill/runs/922966198?check_suite_focus=true#step:11:16):
```
N: Using profile ubuntu/main.
N: Setting up lab in /tmp/temp-lintian-lab-tG6EY1DmS4 ...
N: Starting on group krill/0.7.3-plus-1bionic
N: Unpacking packages in group krill/0.7.3-plus-1bionic
N: ----
N: Processing binary package krill (version 0.7.3-plus-1bionic, arch amd64) ...
E: krill: debian-changelog-file-missing-or-wrong-name
```