### PR TITLE
Work on systemd unit maintainer scripts in-memory instead of on-disk.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rayon = "1.0.3"
 regex = "1.3.1"
 itertools = "0.9.0"
 rust-embed = "5.6.0"
+cfg-if = "0.1.10"
 
 [features]
 default = ["lzma"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ opt-level = 3
 tempdir = "0.3.6"
 mockall = "0.7.2"
 rstest = "0.6.4"
+lazy_static = "1.4.0"
 
 [workspace]
 exclude = ["example"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ cargo_toml = "0.8"
 rayon = "1.0.3"
 regex = "1.3.1"
 itertools = "0.9.0"
-rust-embed = "5.6.0"
+rust-embed = { version = "5.6.0", features = ["compression", "debug-embed"] }
 cfg-if = "0.1.10"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ opt-level = 3
 
 [dev-dependencies]
 tempdir = "0.3.6"
+mockall = "0.7.2"
+rstest = "0.6.4"
 
 [workspace]
 exclude = ["example"]

--- a/autoscripts/README.md
+++ b/autoscripts/README.md
@@ -1,5 +1,0 @@
-These debhelper autoscripts were taken from:
-https://git.launchpad.net/ubuntu/+source/debhelper/tree/autoscripts?h=applied/12.10ubuntu1
-
-To understand which scripts are invoked when, consult:
-https://www.debian.org/doc/debian-policy/ap-flowcharts.html

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -14,7 +14,7 @@
 
 use itertools::Itertools; // for .next_tuple()
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, BTreeSet};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str;
@@ -244,17 +244,17 @@ pub fn generate(
 
     // skip template service files. Enabling, disabling, starting or stopping
     // those services without specifying the instance is not useful.
-    let mut installed_non_template_units: HashSet<String> = HashSet::new();
+    let mut installed_non_template_units: BTreeSet<String> = BTreeSet::new();
     installed_non_template_units.extend(assets
         .iter()
         .filter(|v| v.target_path.starts_with(LIB_SYSTEMD_SYSTEM_DIR))
         .map(|v | fname_from_path(v.target_path.as_path()))
         .filter(|fname| !fname.contains("@")));
 
-    let mut aliases = HashSet::new();
-    let mut enable_units = HashSet::new();
-    let mut start_units = HashSet::new();
-    let mut seen = HashSet::new();
+    let mut aliases = BTreeSet::new();
+    let mut enable_units = BTreeSet::new();
+    let mut start_units = BTreeSet::new();
+    let mut seen = BTreeSet::new();
 
     // note: we do not support handling of services with a sysv-equivalent
     // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n373
@@ -265,7 +265,7 @@ pub fn generate(
     // arrange to be done for them in the maintainer scripts.
     while !units.is_empty() {
         // gather unit names mentioned in 'Also=' kv pairs in the unit files
-        let mut also_units = HashSet::<String>::new();
+        let mut also_units = BTreeSet::<String>::new();
 
         // for each unit that we have not yet processed
         for unit in units.iter() {

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -198,7 +198,6 @@ fn is_comment(s: &str) -> bool {
 /// See:
 ///   https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
 fn unquote(s: &str) -> &str {
-    println!("s: [{}] len={}", s, s.len());
     if s.len() > 1 &&
        ((s.starts_with("\"") && s.ends_with("\"")) ||
        (s.starts_with("'") && s.ends_with("'"))) {

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -23,10 +23,7 @@ use crate::manifest::Asset;
 use crate::dh_lib::*;
 use crate::listener::Listener;
 use crate::util::*;
-
-// the map macro is defined in util.rs but gets exported at the crate root so
-// has to be imported like this:
-use crate::{CDResult, map};
+use crate::CDResult;
 
 /// From man 1 dh_installsystemd on Ubuntu 20.04 LTS. See:
 ///   http://manpages.ubuntu.com/manpages/focal/en/man1/dh_installsystemd.1.html
@@ -234,7 +231,7 @@ pub fn generate(
 
     if !tmp_file_names.is_empty() {
         autoscript(&mut scripts, package, "postinst", "postinst-init-tmpfiles",
-            &map!{ "TMPFILES" => tmp_file_names}, listener)?;
+            &map!{ "TMPFILES" => tmp_file_names }, listener)?;
     }
 
     // add postinst, prerm, and postrm code blocks to handle activation,
@@ -344,17 +341,17 @@ pub fn generate(
         };
         for unit in &enable_units {
             autoscript(&mut scripts, package, "postinst", snippet,
-                &map!{ "UNITFILE" => unit.clone()}, listener)?;
+                &map!{ "UNITFILE" => unit.clone() }, listener)?;
         }
         autoscript(&mut scripts, package, "postrm", "postrm-systemd",
-            &map!{ "UNITFILES" => enable_units.join(" ")}, listener)?;
+            &map!{ "UNITFILES" => enable_units.join(" ") }, listener)?;
     }
 
     // update the maintainer scripts to start units, where the exact action to
     // be taken is influenced by the options passed to us.
     // see: https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n398
     if !start_units.is_empty() {
-        let mut replace = map!{ "UNITFILES" => start_units.join(" ")};
+        let mut replace = map!{ "UNITFILES" => start_units.join(" ") };
 
         if options.no_stop_on_upgrade {
             let snippet;

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -157,7 +157,7 @@ pub fn find_units(
             // Determine the file name that the unit file should be installed as
             // which depends on whether or not a unit name was provided.
             let install_filename = match unit_name {
-                Some(name) => format!("{}.{}", name, actual_suffix),
+                Some(name) => format!("{}{}.{}", name, package_suffix, actual_suffix),
                 None       => format!("{}.{}", package, actual_suffix),
             };
 

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -135,16 +135,16 @@ pub struct Options {
 ///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/dh_installsystemd?h=applied/12.10ubuntu1#n198
 ///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/lib/Debian/Debhelper/Dh_Lib.pm?h=applied/12.10ubuntu1#n957
 pub fn find_units(
-        dir: &PathBuf,
-        package: &str,
+        dir: &Path,
+        main_package: &str,
         unit_name: Option<&str>)
     -> PackageUnitFiles
 {
     let mut installables = HashMap::new();
 
     for (package_suffix, unit_type, install_dir) in SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS.iter() {
-        let package = &format!("{}{}", package, package_suffix);
-        if let Some(src_path) = pkgfile(dir, package, unit_type, unit_name) {
+        let package = &format!("{}{}", main_package, package_suffix);
+        if let Some(src_path) = pkgfile(dir, main_package, package, unit_type, unit_name) {
             // .tmpfile files should be installed in a different directory and
             // with a different extension. See:
             //   https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -149,7 +149,7 @@ pub fn find_units(
             // with a different extension. See:
             //   https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html
             let actual_suffix = match &unit_type[..] {
-                ".tmpfile" => ".conf",
+                "tmpfile" => "conf",
                 _          => unit_type,
             };
 

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -717,7 +717,7 @@ mod tests {
         assert_eq!(0, fragments.len());
     }
 
-    #[rstest(ip, I, ne, rau, ns, nsou,
+    #[rstest(ip, inst, ne, rau, ns, nsou,
       case("ult", false, false, false, false, false),
 
       case("lss", false, false, false, false, false),
@@ -756,7 +756,7 @@ mod tests {
     #[test]
     fn generate_creates_expected_autoscript_fragments(
         ip: &str,
-        I: bool,
+        inst: bool,
         ne: bool,
         rau: bool,
         ns: bool,
@@ -800,7 +800,7 @@ Description=A test unit
 Type=simple
 ".to_owned();
 
-        if I {
+        if inst {
             unit_file_content.push_str("[Install]
 WantedBy=multi-user.target");
         }
@@ -874,7 +874,7 @@ WantedBy=multi-user.target");
             },
             "lss" => {
                 assert_eq!(1, get_read_count(unit_file_path));
-                if I {
+                if inst {
                     match options.no_enable {
                         true  => assert_eq!(1, get_read_count("postinst-systemd-dont-enable")),
                         false => assert_eq!(1, get_read_count("postinst-systemd-enable")),

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -361,11 +361,11 @@ pub fn generate(
             match options.no_start {
                 true => {
                     snippet = "postinst-systemd-restartnostart";
-                    replace.insert("RESTART_ACTION", "try-restart".to_string());
+                    replace.insert("RESTART_ACTION", "try-restart".into());
                 },
                 false => {
                     snippet = "postinst-systemd-restart";
-                    replace.insert("RESTART_ACTION", "restart".to_string());
+                    replace.insert("RESTART_ACTION", "restart".into());
                 }
             };
             autoscript(&mut scripts, package, "postinst", snippet, &replace, listener)?;

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -369,7 +369,7 @@ pub fn generate(
     if !start_units.is_empty() {
         let mut replace = map!{ "UNITFILES" => start_units.join(" ") };
 
-        if options.no_stop_on_upgrade {
+        if options.restart_after_upgrade {
             let snippet;
             match options.no_start {
                 true => {

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -248,7 +248,7 @@ pub fn generate(
 
     if !tmp_file_names.is_empty() {
         autoscript(&mut scripts, package, "postinst", "postinst-init-tmpfiles",
-            &map!{ "TMPFILES" => tmp_file_names }, listener)?;
+            &map!{ "TMPFILES" => tmp_file_names }, false, listener)?;
     }
 
     // add postinst, prerm, and postrm code blocks to handle activation,
@@ -358,10 +358,10 @@ pub fn generate(
         };
         for unit in &enable_units {
             autoscript(&mut scripts, package, "postinst", snippet,
-                &map!{ "UNITFILE" => unit.clone() }, listener)?;
+                &map!{ "UNITFILE" => unit.clone() }, true, listener)?;
         }
         autoscript(&mut scripts, package, "postrm", "postrm-systemd",
-            &map!{ "UNITFILES" => enable_units.join(" ") }, listener)?;
+            &map!{ "UNITFILES" => enable_units.join(" ") }, false, listener)?;
     }
 
     // update the maintainer scripts to start units, where the exact action to
@@ -382,27 +382,27 @@ pub fn generate(
                     replace.insert("RESTART_ACTION", "restart".into());
                 }
             };
-            autoscript(&mut scripts, package, "postinst", snippet, &replace, listener)?;
+            autoscript(&mut scripts, package, "postinst", snippet, &replace, true, listener)?;
         } else {
             if !options.no_start {
                 // (stop|start) service (before|after) upgrade
-                autoscript(&mut scripts, package, "postinst", "postinst-systemd-start", &replace, listener)?;
+                autoscript(&mut scripts, package, "postinst", "postinst-systemd-start", &replace, true, listener)?;
             }
         }
 
         if options.no_stop_on_upgrade || options.restart_after_upgrade {
             // stop service only on remove
-			autoscript(&mut scripts, package, "prerm", "prerm-systemd-restart", &replace, listener)?;
+			autoscript(&mut scripts, package, "prerm", "prerm-systemd-restart", &replace, true, listener)?;
         } else {
             if !options.no_start {
                 // always stop service
-                autoscript(&mut scripts, package, "prerm", "prerm-systemd", &replace, listener)?;
+                autoscript(&mut scripts, package, "prerm", "prerm-systemd", &replace, true, listener)?;
             }
         }
 
         // Run this with "default" order so it is always after other service
         // related autosnippets.
-		autoscript(&mut scripts, package, "postrm", "postrm-systemd-reload-only", &replace, listener)?;
+		autoscript(&mut scripts, package, "postrm", "postrm-systemd-reload-only", &replace, false, listener)?;
     }
 
     Ok(scripts)

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -534,6 +534,19 @@ mod tests {
             "debian/mypkg.tmpfile", // no unit but should be matched as fallback
             "debian/mypkg.myunit.service", // should be matched over main package match above
         ]);
+
+        // add some paths that should not be matched
+        add_test_fs_paths(&vec![
+            "debian/nested/dir/mykpg.myunit.mount",
+            "debian/README.md",
+            "mypkg.myunit.mount",
+            "mypkg.mount",
+            "mount",
+            "postinit",
+            "mypkg.postinit",
+            "mypkg.myunit.postinit"
+        ]);
+
         let pkg_unit_files = find_units(Path::new("debian"), "mypkg", Some("myunit"));
         // note the "myunit" target names, even when the match was less specific
         assert_eq_found_unit(&pkg_unit_files, "lib/systemd/system/myunit.mount",   "debian/mypkg.myunit.mount");
@@ -542,7 +555,10 @@ mod tests {
         assert_eq_found_unit(&pkg_unit_files, "lib/systemd/system/myunit@.socket", "debian/mypkg@.myunit.socket");
         assert_eq_found_unit(&pkg_unit_files, "lib/systemd/system/myunit.target",  "debian/target");
         assert_eq_found_unit(&pkg_unit_files, "lib/systemd/system/myunit@.timer",  "debian/mypkg@.myunit.timer");
+
+        // note the changed file extension
         assert_eq_found_unit(&pkg_unit_files, "usr/lib/tmpfiles.d/myunit.conf",    "debian/mypkg.tmpfile");
+
         assert_eq!(7, pkg_unit_files.len());
     }
 }

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -145,7 +145,7 @@ pub(crate) fn autoscript(
         if !replacements.is_empty() {
             let existing_text = std::str::from_utf8(scripts.get(&outfile).unwrap())?;
 
-            // prepend new text to existing file
+            // prepend new text to existing script fragment
             let mut new_text = String::new();
             new_text.push_str(&format!("# Automatically added by {}\n", bin_name));
             new_text.push_str(&autoscript_sed(snippet_filename, replacements));
@@ -157,8 +157,9 @@ pub(crate) fn autoscript(
             unimplemented!();
         }
     } else if !replacements.is_empty() {
-        let mut new_text = String::new();
-        new_text.push_str(&format!("# Automatically added by {:?}\n", bin_name));
+        // append to existing script fragment (if any)
+        let mut new_text = String::from(std::str::from_utf8(scripts.get(&outfile).unwrap_or(&Vec::new()))?);
+        new_text.push_str(&format!("# Automatically added by {}\n", bin_name));
         new_text.push_str(&autoscript_sed(snippet_filename, replacements));
         new_text.push_str("# End automatically added section\n");
         scripts.insert(outfile, new_text.into());

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -152,12 +152,14 @@ pub(crate) fn autoscript(
     script: &str,
     snippet_filename: &str,
     replacements: &HashMap<&str, String>,
+    service_order: bool,
     listener: &mut dyn Listener) -> CDResult<()>
 {
     let bin_name = std::env::current_exe().unwrap();
     let bin_name = bin_name.file_name().unwrap();
     let bin_name = bin_name.to_str().unwrap();
-    let outfile = format!("{}.{}.debhelper", package, script);
+    let outfile_ext = if service_order { "service" } else { "debhelper" };
+    let outfile = format!("{}.{}.{}", package, script, outfile_ext);
 
     listener.info(format!("Maintainer script {} will be augmented with autoscript {}", &script, snippet_filename));
 
@@ -397,7 +399,7 @@ mod tests {
         mock_listener.expect_info().times(1).return_const(());
         let mut scripts = scripts.unwrap_or(ScriptFragments::new());
         let replacements = map!{ "UNITFILES" => unit.to_owned() };
-        autoscript(&mut scripts, pkg, script, snippet, &replacements, &mut mock_listener).unwrap();
+        autoscript(&mut scripts, pkg, script, snippet, &replacements, false, &mut mock_listener).unwrap();
         return scripts;
     }
 
@@ -417,7 +419,7 @@ mod tests {
         // sed mode is when no search -> replacement pairs are defined
         let sed_mode = &HashMap::new();
 
-        autoscript(&mut scripts, "mypkg", "somescript", "idontexist", sed_mode, &mut mock_listener).unwrap();
+        autoscript(&mut scripts, "mypkg", "somescript", "idontexist", sed_mode, false, &mut mock_listener).unwrap();
     }
 
     #[test]

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -220,7 +220,7 @@ fn debhelper_script_subst(user_scripts_dir: &Path, scripts: &mut ScriptFragments
         if new_text == user_text {
             return Err(CargoDebError::DebHelperReplaceFailed(user_file_path));
         }
-        scripts.insert(script.to_string(), new_text.into());
+        scripts.insert(script.into(), new_text.into());
     } else if let Some(generated_bytes) = scripts.get(&generated_file_name) {
         listener.info(format!("Generating maintainer script {}", script));
 
@@ -230,7 +230,7 @@ fn debhelper_script_subst(user_scripts_dir: &Path, scripts: &mut ScriptFragments
         new_text.push_str("set -e\n");
         new_text.push_str(std::str::from_utf8(generated_bytes)?);
 
-        scripts.insert(script.to_string(), new_text.into());
+        scripts.insert(script.into(), new_text.into());
     }
 
     Ok(())

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -23,8 +23,11 @@ use std::path::{Path, PathBuf};
 use crate::{CDResult, listener::Listener};
 use crate::error::*;
 
-/// DebHelper autoscripts are embedded in the Rust library binary. For more
-/// information about the source of the scripts see `autoscripts/README.md`.
+/// DebHelper autoscripts are embedded in the Rust library binary.
+/// The autoscripts were taken from:
+///   https://git.launchpad.net/ubuntu/+source/debhelper/tree/autoscripts?h=applied/12.10ubuntu1
+/// To understand which scripts are invoked when, consult:
+///   https://www.debian.org/doc/debian-policy/ap-flowcharts.htm
 #[derive(RustEmbed)]
 #[folder = "autoscripts/"]
 struct Autoscripts;

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ quick_error! {
         BuildFailed {
             display("build failed")
         }
+        DebHelperReplaceFailed(name: PathBuf) {
+            display("unable to replace #DEBHELPER# token in maintainer script '{}'", name.display())
+        }
         StripFailed(name: PathBuf, reason: String) {
             display("unable to strip binary '{}': {}", name.display(), reason)
         }
@@ -54,6 +57,10 @@ quick_error! {
             from()
             display("unable to parse `cargo metadata` output")
             cause(err)
+        }
+        ParseUTF8(err: std::str::Utf8Error) {
+            from()
+            from(err: std::string::FromUtf8Error) -> (err.utf8_error())
         }
         PackageNotFound(path: String, reason: Vec<u8>) {
             display("path '{}' does not belong to a package: {}", path, String::from_utf8_lossy(reason))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ cargo deb # run this in your Cargo project directory
 The library interface is experimental. See `main.rs` for usage.
 */
 
+#[macro_use] extern crate cfg_if;
 #[macro_use] extern crate quick_error;
+
 pub mod compress;
 pub mod control;
 pub mod data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub use crate::debarchive::DebArchive;
 pub use crate::error::*;
 pub use crate::manifest::Config;
 
+#[macro_use]
+mod util;
 mod config;
 mod debarchive;
 mod dependencies;
@@ -38,7 +40,6 @@ mod tararchive;
 mod wordsplit;
 mod dh_installsystemd;
 mod dh_lib;
-mod util;
 
 use crate::listener::Listener;
 use std::env;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(test, mockall::automock)]
 pub trait Listener: Send + Sync {
     fn warning(&self, s: String);
     fn info(&self, s: String);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1032,6 +1032,7 @@ pub(crate) fn get_arch(target: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::add_test_fs_paths;
 
     #[test]
     fn match_arm_arch() {
@@ -1139,6 +1140,70 @@ mod tests {
         let a = AssetSource::Data(data);
 
         assert_eq!(a.debug_source(), None);
+    }
+
+    fn to_canon_static_str(s: &str) -> &'static str {
+        let cwd = std::env::current_dir().unwrap();
+        let abs_path = cwd.join(s);
+        let abs_path_string = abs_path.to_string_lossy().into_owned();
+        Box::leak(abs_path_string.into_boxed_str())
+    }
+
+    #[test]
+    fn add_systemd_assets_with_no_config_does_nothing() {
+        let mut mock_listener = crate::listener::MockListener::new();
+        mock_listener.expect_info().return_const(());
+
+        // supply a systemd unit file as if it were available on disk
+        add_test_fs_paths(&vec![to_canon_static_str("cargo-deb.service")]);
+
+        let config = Config::from_manifest(
+            Path::new("Cargo.toml"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &mut mock_listener,
+        ).unwrap();
+
+        let num_unit_assets = config.assets.resolved
+            .iter()
+            .filter(|v| v.target_path.starts_with("lib/systemd/system/"))
+            .count();
+
+        assert_eq!(0, num_unit_assets);
+    }
+
+    #[test]
+    fn add_systemd_assets_with_config_adds_unit_assets() {
+        let mut mock_listener = crate::listener::MockListener::new();
+        mock_listener.expect_info().return_const(());
+
+        // supply a systemd unit file as if it were available on disk
+        add_test_fs_paths(&vec![to_canon_static_str("cargo-deb.service")]);
+
+        let mut config = Config::from_manifest(
+            Path::new("Cargo.toml"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &mut mock_listener,
+        ).unwrap();
+
+        config.systemd_units.get_or_insert(SystemdUnitsConfig::default());
+        config.maintainer_scripts.get_or_insert(PathBuf::new());
+
+        config.add_systemd_assets().unwrap();
+
+        let num_unit_assets = config.assets.resolved
+            .iter()
+            .filter(|v| v.target_path.starts_with("lib/systemd/system/"))
+            .count();
+
+        assert_eq!(1, num_unit_assets);
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -412,8 +412,6 @@ impl Config {
     }
 
     pub fn resolve_assets(&mut self) -> CDResult<()> {
-        self.add_systemd_assets()?;
-
         for UnresolvedAsset { source_path, target_path, chmod, is_built } in self.assets.unresolved.drain(..) {
             let source_prefix: PathBuf = source_path.iter()
                 .take_while(|part| !is_glob_pattern(part.to_str().unwrap()))
@@ -744,6 +742,7 @@ impl Cargo {
         config.assets = assets;
         config.add_copyright_asset()?;
         config.add_changelog_asset()?;
+        config.add_systemd_assets()?;
 
         Ok(config)
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -4,6 +4,7 @@ use crate::error::*;
 use crate::listener::Listener;
 use crate::ok_or::OkOrThen;
 use crate::dh_installsystemd;
+use crate::util::read_file_to_bytes;
 use rayon::prelude::*;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -48,7 +49,7 @@ impl AssetSource {
     pub fn data(&self) -> CDResult<Cow<'_, [u8]>> {
         Ok(match *self {
             AssetSource::Path(ref p) => {
-                let data = fs::read(p)
+                let data = read_file_to_bytes(p)
                     .map_err(|e| CargoDebError::IoFile("unable to read asset to add to archive", e, p.to_owned()))?;
                 Cow::Owned(data)
             },

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 /// Get the filename from a path. Intended to be replaced when testing.
 pub(crate) fn fname_from_path(path: &Path) -> String {
-    path.file_name().unwrap().to_string_lossy().to_string()
+    path.file_name().unwrap().to_string_lossy().into()
 }
 
 /// Create a HashMap from one or more key => value pairs in a single statement.

--- a/src/util.rs
+++ b/src/util.rs
@@ -123,7 +123,7 @@ cfg_if! {
         use std::sync::Mutex;
 
         pub(crate) struct TestPath {
-            filename: &'static str,
+            _filename: &'static str,
             contents: String,
             read_count: u16
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,10 +8,29 @@ pub(crate) fn fname_from_path(path: &Path) -> String {
 
 /// Create a HashMap from one or more key => value pairs in a single statement.
 /// 
+/// # Usage
+/// 
+/// Any types supported by HashMap for keys and values are supported:
+/// ```
+/// let mut one = std::collections::HashMap::new();
+/// one.insert(1, 'a');
+/// assert_eq!(one, map!{ 1 => 'a' });
+///
+/// let mut two = std::collections::HashMap::new();
+/// two.insert("a", 1);
+/// two.insert("b", 2);
+/// assert_eq!(two, map!{ "a" => 1, "b" => 2 });
+/// ```
+/// 
+/// Empty maps are not supported, attempting to create one will fail to compile:
+/// ```compile_fail
+/// let empty = std::collections::HashMap::new();
+/// assert_eq!(empty, map!{ });
+/// ```
+/// 
 /// # Provenance
 /// 
 /// From: https://stackoverflow.com/a/27582993
-#[macro_export]
 macro_rules! map(
     { $($key:expr => $value:expr),+ } => {
         {
@@ -43,7 +62,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hashset_join() {
+    fn map_macro() {
+        let mut one = std::collections::HashMap::new();
+        one.insert(1, 'a');
+        assert_eq!(one, map!{ 1 => 'a' });
+
+        let mut two = std::collections::HashMap::new();
+        two.insert("a", 1);
+        two.insert("b", 2);
+        assert_eq!(two, map!{ "a" => 1, "b" => 2 });
+    }
         let empty: BTreeSet<String> = vec![].into_iter().collect();
         assert_eq!("", empty.join(""));
         assert_eq!("", empty.join(","));

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Get the filename from a path. Intended to be replaced when testing.
 /// Note: Due to the way the Path type works the final component is returned
@@ -8,6 +8,18 @@ pub(crate) fn fname_from_path(path: &Path) -> String {
     path.file_name().unwrap().to_string_lossy().into()
 }
 
+
+cfg_if! {
+    if #[cfg(not(test))] {
+        pub(crate) fn is_path_file(path: &PathBuf) -> bool {
+            path.is_file()
+        }
+
+        pub(crate) fn read_file_to_string(path: &Path) -> std::io::Result<String> {
+            std::fs::read_to_string(path)
+        }
+    }
+}
 /// Create a HashMap from one or more key => value pairs in a single statement.
 /// 
 /// # Usage
@@ -64,6 +76,89 @@ pub(crate) trait MyJoin {
 impl MyJoin for BTreeSet<String> {
     fn join(&self, sep: &str) -> String {
         self.iter().map(|item| item.as_str()).collect::<Vec<&str>>().join(sep)
+    }
+}
+
+cfg_if! {
+    if #[cfg(test)] {
+        use std::collections::HashMap;
+
+        // ---------------------------------------------------------------------
+        // Begin: test virtual filesystem
+        // ---------------------------------------------------------------------
+        // The pkgfile() function accesses the filesystem directly via its use
+        // the Path(Buf)::is_file() method which checks for the existence of a
+        // file in the real filesystem.
+        //
+        // To test this without having to create real files and directories we
+        // extend the PathBuf type via a trait with a mock_is_file() method
+        // which, in test builds, is used by pkgfile() instead of the real
+        // PathBuf::is_file() method.
+        //
+        // The mock_is_file() method looks up a path in a vector which
+        // represents a set of paths in a virtual filesystem. However, accessing
+        // global state in a multithreaded test run is unsafe, plus we want each
+        // test to define its own virtual filesystem to test against, not a
+        // single global virtual filesystem shared by all tests.
+        //
+        // This test specific virtual filesystem is implemented as a map,
+        // protected by a thread local such that each test (thread) gets its own
+        // instance. To be able to mutate the map it is wrapped inside a Mutex.
+        // To make this setup easier to work with we define a few  helper
+        // functions:
+        //
+        //   - add_test_fs_paths() - adds paths to the current tests virtual fs
+        //   - set_test_fs_path_content() - set the file content (initially "")
+        //   - with_test_fs() - passes the current tests virtual fs vector to
+        //                      a user defined callback function.
+        use std::sync::Mutex;
+
+        thread_local!(
+            static MOCK_FS: Mutex<HashMap<&'static str, String>> = Mutex::new(HashMap::new())
+        );
+
+        pub(crate) fn add_test_fs_paths(paths: &Vec<&'static str>) {
+            MOCK_FS.with(|fs| {
+                let mut fs_map = fs.lock().unwrap();
+                for path in paths {
+                    fs_map.insert(path, "".to_owned());
+                }
+            })
+        }
+
+        pub(crate) fn set_test_fs_path_content(path: &'static str, contents: String) {
+            MOCK_FS.with(|fs| {
+                let mut fs_map = fs.lock().unwrap();
+                fs_map.insert(path, contents);
+            })
+        }
+
+        fn with_test_fs<F, R>(callback: F) -> R
+        where
+            F: Fn(&HashMap<&'static str, String>) -> R
+        {
+            MOCK_FS.with(|fs| callback(&fs.lock().unwrap()))
+        }
+
+        pub(crate) fn is_path_file(path: &PathBuf) -> bool {
+            with_test_fs(|fs| {
+                fs.contains_key(&path.to_str().unwrap())
+            })
+        }
+
+        pub(crate) fn read_file_to_string(path: &Path) -> std::io::Result<String> {
+            with_test_fs(|fs| {
+                match fs.get(&path.to_str().unwrap()) {
+                    Some(contents) => Ok(contents.clone()),
+                    None           => Err(std::io::Error::new(std::io::ErrorKind::NotFound,
+                        format!("Test filesystem path {:?} does not exist", path)))
+                }
+            })
+        }
+
+        // ---------------------------------------------------------------------
+        // End: test virtual filesystem
+        // ---------------------------------------------------------------------
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::path::Path;
 
 /// Get the filename from a path. Intended to be replaced when testing.
@@ -32,8 +32,28 @@ pub(crate) trait MyJoin {
 
 /// Returns a String containing the hash set items joined together by the given
 /// separator.
-impl MyJoin for HashSet<String> {
+impl MyJoin for BTreeSet<String> {
     fn join(&self, sep: &str) -> String {
         self.iter().map(|item| item.as_str()).collect::<Vec<&str>>().join(sep)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashset_join() {
+        let empty: BTreeSet<String> = vec![].into_iter().collect();
+        assert_eq!("", empty.join(""));
+        assert_eq!("", empty.join(","));
+
+        let one: BTreeSet<String> = vec!["a"].into_iter().map(|s| s.to_owned()).collect();
+        assert_eq!("a", one.join(""));
+        assert_eq!("a", one.join(","));
+
+        let two: BTreeSet<String> = vec!["a", "b"].into_iter().map(|s| s.to_owned()).collect();
+        assert_eq!("ab", two.join(""));
+        assert_eq!("a,b", two.join(","));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 /// Get the filename from a path. Intended to be replaced when testing.
+/// Note: Due to the way the Path type works the final component is returned
+/// even if it looks like a directory, e.g. "/some/dir/" will return "dir"...
 pub(crate) fn fname_from_path(path: &Path) -> String {
     path.file_name().unwrap().to_string_lossy().into()
 }
@@ -68,6 +70,30 @@ impl MyJoin for BTreeSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fname_from_path_returns_file_name_even_if_file_does_not_exist() {
+        assert_eq!("some_name", fname_from_path(Path::new("some_name")));
+        assert_eq!("some_name", fname_from_path(Path::new("/some_name")));
+        assert_eq!("some_name", fname_from_path(Path::new("/a/b/some_name")));
+    }
+
+    #[test]
+    fn fname_from_path_returns_file_name_even_if_it_looks_like_a_directory() {
+        assert_eq!("some_name", fname_from_path(Path::new("some_name/")));
+    }
+
+    #[test]
+    #[should_panic]
+    fn fname_from_path_panics_when_path_is_empty() {
+        assert_eq!("", fname_from_path(Path::new("")));
+    }
+
+    #[test]
+    #[should_panic]
+    fn fname_from_path_panics_when_path_has_no_filename() {
+        assert_eq!("", fname_from_path(Path::new("/a/")));
+    }
 
     #[test]
     fn map_macro() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -131,7 +131,7 @@ cfg_if! {
         impl TestPath {
             fn new(filename: &'static str, contents: String) -> Self {
                 TestPath {
-                    filename: filename,
+                    _filename: filename,
                     contents: contents,
                     read_count: 0
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -51,6 +51,14 @@ pub(crate) trait MyJoin {
 
 /// Returns a String containing the hash set items joined together by the given
 /// separator.
+/// 
+/// # Usage
+/// 
+/// ```text
+/// let two: BTreeSet<String> = vec!["a", "b"].into_iter().map(|s| s.to_owned()).collect();
+/// assert_eq!("ab", two.join(""));
+/// assert_eq!("a,b", two.join(","));
+/// ```
 impl MyJoin for BTreeSet<String> {
     fn join(&self, sep: &str) -> String {
         self.iter().map(|item| item.as_str()).collect::<Vec<&str>>().join(sep)
@@ -72,6 +80,9 @@ mod tests {
         two.insert("b", 2);
         assert_eq!(two, map!{ "a" => 1, "b" => 2 });
     }
+
+    #[test]
+    fn btreeset_join() {
         let empty: BTreeSet<String> = vec![].into_iter().collect();
         assert_eq!("", empty.join(""));
         assert_eq!("", empty.join(","));

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,14 +1,9 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-/// Get the filename from a path. Intended to be erplaced when testing.
+/// Get the filename from a path. Intended to be replaced when testing.
 pub(crate) fn fname_from_path(path: &Path) -> String {
     path.file_name().unwrap().to_string_lossy().to_string()
-}
-
-/// Copy a file from `from` to `to`. Intended to be replaced when testing.
-pub(crate) fn copy_file(from: &Path, to: &Path) -> std::io::Result<u64> {
-    std::fs::copy(&from, &to)
 }
 
 /// Create a HashMap from one or more key => value pairs in a single statement.
@@ -45,16 +40,4 @@ impl MyJoin for HashSet<String> {
         }
         v.join(sep)
     }
-}
-
-/// Return Some(path) to the first directory in the `search_dirs` array that
-/// contains an immediate child file with name `filename`, if found, else None.
-pub(crate) fn find_first(search_dirs: &[PathBuf], filename: &str) -> Option<PathBuf> {
-    search_dirs.iter().find_map(|dir| {
-        let abs_path = dir.join(filename);
-        match abs_path.exists() {
-            true => Some(abs_path),
-            false => None
-        }
-    })
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,10 +34,6 @@ pub(crate) trait MyJoin {
 /// separator.
 impl MyJoin for HashSet<String> {
     fn join(&self, sep: &str) -> String {
-        let mut v = Vec::<&str>::new();
-        for item in self.iter() {
-            v.push(item.as_str());
-        }
-        v.join(sep)
+        self.iter().map(|item| item.as_str()).collect::<Vec<&str>>().join(sep)
     }
 }


### PR DESCRIPTION
Initial implementation. Seems to work but I will add unit tests to verify that for sure. Created as a **draft** PR to communicate progress toward the request on PR #135 to _"use in-memory objects instead of file rewrites and appends"_ and to get feedback as early as possible while I write unit tests.

Other changes in this PR:
- Use more `?` error propagation and fewer unwraps/panics.
- Remove the info message about adding archive files to be more consistent with the existing calls to `archive.file()` which occur silently.