### PR TITLE
fix `dpkg -i` failure caused by whitespace line

### DIFF
--- a/src/wordsplit.rs
+++ b/src/wordsplit.rs
@@ -7,7 +7,7 @@ impl WordSplit for str {
         let output_capacity = self.len() + self.len() % length + 1;
         let mut lines: Vec<String> = Vec::with_capacity(output_capacity);
         for line in self.lines() {
-            if line.is_empty() {
+            if line.chars().all(char::is_whitespace) {
                 lines.push(String::from("."));
                 continue;
             }


### PR DESCRIPTION
If readme file contains any whitespace-only line, `dpkg -i` failed with "blank line in value of field 'Description'".
For example, I failed to install [chmln/sd](https://github.com/chmln/sd) due to this issue.

`split_by_chars()` should convert not only empty lines, but also whitespace lines.