### PR TITLE
fix `dpkg -i` failure caused by indented long word

### DIFF
--- a/src/wordsplit.rs
+++ b/src/wordsplit.rs
@@ -7,7 +7,7 @@ impl WordSplit for str {
         let output_capacity = self.len() + self.len() % length + 1;
         let mut lines: Vec<String> = Vec::with_capacity(output_capacity);
         for line in self.lines() {
-            if line.is_empty() {
+            if line.chars().all(char::is_whitespace) {
                 lines.push(String::from("."));
                 continue;
             }

--- a/src/wordsplit.rs
+++ b/src/wordsplit.rs
@@ -3,37 +3,60 @@ pub trait WordSplit {
 }
 
 impl WordSplit for str {
+    // ref: https://www.debian.org/doc/debian-policy/ch-controlfields.html#description
+    //
+    // * Extended description line must have at least one non-whitespace character.
+    //   If you violate this rule, `dpkg -i` will fail.
+    // * Extended description line must not have any tab character.
+    //   If you violate this rule, the effect is not predictable.
+    //
+    // NOTE: as for extended description, this splitting might not be necessary in the first place?
+    // (debian policy seems to say nothing about line length of extended description)
     fn split_by_chars(&self, length: usize) -> Vec<String> {
         let output_capacity = self.len() + self.len() % length + 1;
         let mut lines: Vec<String> = Vec::with_capacity(output_capacity);
         for line in self.lines() {
+            let line = line.replace("\t", " ");
+
+            // consider whitespace line as empty
             if line.chars().all(char::is_whitespace) {
                 lines.push(String::from("."));
                 continue;
             }
+
             let words: Vec<&str> = line.split(' ').collect();
             let mut current_line = String::with_capacity(length);
-            let (mut chars, mut initialized) = (0, false);
-            for word in words {
-                if chars + word.len() >= length {
-                    // if character length met or exceeded
-                    if !current_line.is_empty() {
-                        lines.push(current_line.clone());
+            let mut initialized = false;
+            macro_rules! append_word {
+                ($word:expr) => {{
+                    if initialized {
+                        current_line += " ";
                     }
-                    current_line.clear();
-                    current_line += word;
-                    chars = word.len();
-                } else if !initialized {
-                    current_line += word;
-                    chars = word.len();
                     initialized = true;
+                    current_line += $word;
+                }};
+            }
+            for word in words {
+                // we need at least one non-whitespace character
+                if current_line.chars().all(char::is_whitespace) {
+                    append_word!(word);
+                    continue;
+                }
+
+                // now current_line has non-whitespace character
+                if current_line.len() + word.len() >= length {
+                    // if character length met or exceeded
+                    lines.push(current_line.clone());
+                    current_line = word.to_owned(); // skip a space
                 } else {
-                    current_line += " ";
-                    current_line += word;
-                    chars += word.len() + 1;
+                    append_word!(word);
                 }
             }
-            if !current_line.is_empty() {
+
+            // current_line may be trailing whitespaces
+            if current_line.chars().all(char::is_whitespace) {
+                lines.push(String::from("."));
+            } else {
                 lines.push(current_line);
             }
         }
@@ -43,24 +66,71 @@ impl WordSplit for str {
 
 #[test]
 fn test_split_by_chars() {
-    let input = String::from("This is a test string for split_by_chars.");
-    let sections = input.split_by_chars(10);
-    let mut iter = sections.iter();
-    assert_eq!(9, iter.next().unwrap().len());
-    assert_eq!(4, iter.next().unwrap().len());
-    assert_eq!(10, iter.next().unwrap().len());
-    assert_eq!(15, iter.next().unwrap().len());
-    let input = String::from("This is a line\n\nthis is also a line.");
-    let test = vec![
-        String::from("This is a line"),
-        String::from("."),
-        String::from("this is also a line."),
-    ];
-    assert_eq!(test, input.split_by_chars(79));
-}
+    #[allow(non_snake_case)]
+    fn S(s: &'static str) -> String { s.to_owned() }
 
-#[test]
-fn test_split_by_chars_long_word() {
-    let lines = "sh\nverylongwordverylongwordverylongwordverylongword\nend".split_by_chars(5);
-    assert_eq!(3, lines.len());
+    assert_eq!("This is a test string for split_by_chars.".split_by_chars(10), vec![
+        S("This is a"),
+        S("test"),
+        S("string for"),
+        S("split_by_chars.")
+    ]);
+
+    assert_eq!("This is a line\n\nthis is also a line.".split_by_chars(79), vec![
+        S("This is a line"),
+        S("."),
+        S("this is also a line."),
+    ]);
+
+    assert_eq!("This is a line\n  \nthis is also a line.\n".split_by_chars(79), vec![
+        S("This is a line"),
+        S("."),
+        S("this is also a line."),
+    ]);
+
+    assert_eq!("    This  is an 4-indented line\n".split_by_chars(79), vec![
+        S("    This  is an 4-indented line"),
+    ]);
+
+    assert_eq!("    This  is an 4-indented line\n".split_by_chars(3), vec![
+        S("    This"),
+        S(" is"),
+        S("an"),
+        S("4-indented"),
+        S("line"),
+    ]);
+
+    assert_eq!("    indent,    then space".split_by_chars(4), vec![
+        S("    indent,"),
+        S("   then"),
+        S("space"),
+    ]);
+
+    assert_eq!("  trailing space    ".split_by_chars(12), vec![
+        S("  trailing"),
+        S("space    "),
+    ]);
+
+    assert_eq!("  trailing space    ".split_by_chars(16), vec![
+        S("  trailing space"),
+        S("."),
+    ]);
+
+    assert_eq!("sh\nverylongwordverylongwordverylongwordverylongword\nend".split_by_chars(5), vec![
+        S("sh"),
+        S("verylongwordverylongwordverylongwordverylongword"),
+        S("end"),
+    ]);
+
+    // from alacritty
+    assert_eq!("       src=\"https://cloud.githubusercontent.com/assets/4285147/21585004/2ebd0288-d06c-11e6-95d3-4a2889dbbd6f.png\">".split_by_chars(79), vec![
+        S("       src=\"https://cloud.githubusercontent.com/assets/4285147/21585004/2ebd0288-d06c-11e6-95d3-4a2889dbbd6f.png\">"),
+    ]);
+
+    assert_eq!("\t\ttabs are\treplaced with spaces\t".split_by_chars(10), vec![
+        S("  tabs are"),
+        S("replaced"),
+        S("with"),
+        S("spaces "),
+    ]);
 }


### PR DESCRIPTION
This should fix #142, and added some tests.