### PR TITLE
Add support for the 'Recommends' manifest field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Everything is optional:
 - **copyright**: To whom and when the copyright of the software is granted. If not present, the list of authors is used.
 - **license-file**: 2-element array with a location of the license file and the amount of lines to skip at the top. If not present, package-level `license-file` is used.
 - **depends**: The runtime [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. Generated automatically when absent, or if the list includes the `$auto` keyword.
+- **recommends**: The recommended [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. This will be empty by default.
 - **conflicts**, **breaks**, **replaces**, **provides** — [package transition](https://wiki.debian.org/PackageTransition) control.
 - **extended-description**: An extended description of the project — the more detailed the better. Either **extended-description-file** (see below) or package's `readme` file is used if it is not provided.
 - **extended-description-file**: A file with extended description of the project. When specified, used if **extended-description** is not provided.

--- a/src/control.rs
+++ b/src/control.rs
@@ -159,6 +159,14 @@ fn generate_control(archive: &mut Archive, options: &Config, listener: &mut dyn 
         writeln!(&mut control, "Build-Depends: {}", build_depends)?;
     }
 
+    if let Some(ref recommends) = options.recommends {
+        let recommends_normalized = recommends.trim();
+
+        if !recommends_normalized.is_empty() {
+            writeln!(&mut control, "Recommends: {}", recommends_normalized)?;
+        }
+    }
+
     if let Some(ref conflicts) = options.conflicts {
         writeln!(&mut control, "Conflicts: {}", conflicts)?;
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -302,6 +302,8 @@ pub struct Config {
     pub depends: String,
     /// The Debian dependencies required to build the project.
     pub build_depends: Option<String>,
+    /// The Debian recommended dependencies.
+    pub recommends: Option<String>,
     /// The Debian software category to which the package belongs.
     pub section: Option<String>,
     /// The Debian priority of the project. Typically 'optional'.
@@ -705,6 +707,7 @@ impl Cargo {
             })?,
             depends: deb.depends.take().unwrap_or_else(|| "$auto".to_owned()),
             build_depends: deb.build_depends.take(),
+            recommends: deb.recommends.take(),
             conflicts: deb.conflicts.take(),
             breaks: deb.breaks.take(),
             replaces: deb.replaces.take(),
@@ -893,6 +896,7 @@ struct CargoDeb {
     pub changelog: Option<String>,
     pub depends: Option<String>,
     pub build_depends: Option<String>,
+    pub recommends: Option<String>,
     pub conflicts: Option<String>,
     pub breaks: Option<String>,
     pub replaces: Option<String>,
@@ -924,6 +928,7 @@ impl CargoDeb {
             changelog: self.changelog.or(parent.changelog),
             depends: self.depends.or(parent.depends),
             build_depends: self.build_depends.or(parent.build_depends),
+            recommends: self.recommends.or(parent.recommends),
             conflicts: self.conflicts.or(parent.conflicts),
             breaks: self.breaks.or(parent.breaks),
             replaces: self.replaces.or(parent.replaces),


### PR DESCRIPTION
I think I made all the required changes. I couldn't find tests for most of this, but I did locally install the binary and modify the example project to verify that the "Recommends" field will appear in the package manifest if the configuration item is specified. If this looks good, I can round out support for "Suggests" and any other similar fields.