### PR TITLE
Enable parallel xz compression out of the box

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "lazy_static",
  "md5",
  "mockall",
+ "num_cpus",
  "quick-error",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,11 @@ cargo_toml = "0.8"
 rayon = "1.0.3"
 regex = "1.3.1"
 itertools = "0.10"
+num_cpus = { version = "1.13", optional = true }
 
 [features]
 default = ["lzma"]
-lzma = ["xz2"]
+lzma = ["xz2", "num_cpus"]
 
 [profile.release]
 lto = true
@@ -76,4 +77,3 @@ exclude = ["example"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,10 @@ quick_error! {
             display("unable to iterate asset glob result")
             source(err)
         }
+        #[cfg(feature = "lzma")]
+        LzmaCompressionError(err: xz2::stream::Error) {
+            display("lzma compression error: {:?}", err)
+        }
     }
 }
 


### PR DESCRIPTION
There's no difference on smaller binaries, since they don't get spread across multiple lzma blocks to have anything to parallelize, but for bigger binaries with many dependencies there's a noticeable win.

Below are the numbers from embedding 100MB of `/dev/urandom` into `cargo-deb` itself and running it on my Macbook Air with M1 processor.

* Fast mode

```
real 0m3.597s
user 0m24.262s
sys  0m0.265s
```

* Regular mode:

```
real 0m9.833s
user 0m37.334s
sys  0m0.529s
```