### PR TITLE
Prefer absolute paths for latest compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/cargo-deb", "usr/bin/", "755"],
-    ["README.md", "usr/share/doc/cargo-deb/README", "644"],
+    ["target/release/cargo-deb", "/usr/bin/", "755"],
+    ["README.md", "/usr/share/doc/cargo-deb/README", "644"],
 ]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/cargo-deb", "usr/bin/", "755"],
-    ["README.md", "usr/share/doc/cargo-deb/README", "644"],
+    ["target/release/cargo-deb", "/usr/bin/", "755"],
+    ["README.md", "/usr/share/doc/cargo-deb/README", "644"],
 ]
 ```
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -16,11 +16,11 @@ section = "utils"
 priority = "optional"
 assets = [
     # binary
-    ["target/release/example", "usr/bin/", "755"],
+    ["target/release/example", "/usr/bin/", "755"],
     # assets
-    ["assets/*", "var/lib/example", "644"],
-    ["target/release/assets/*", "var/lib/example", "644"],
-    ["3.txt", "var/lib/example/3.txt", "644"],
+    ["assets/*", "/var/lib/example", "644"],
+    ["target/release/assets/*", "/var/lib/example", "644"],
+    ["3.txt", "/var/lib/example/3.txt", "644"],
 ]
 changelog = "changelog"
 default-features = false
@@ -29,11 +29,11 @@ features = ["example_debian_build"]
 [package.metadata.deb.variants.debug]
 assets =  [
     # binary
-    ["target/release/example", "usr/bin/", "755"],
+    ["target/release/example", "/usr/bin/", "755"],
     # assets
-    ["assets/*", "var/lib/example", "644"],
-    ["target/release/assets/*", "var/lib/example", "644"],
-    ["4.txt", "var/lib/example/4.txt", "644"],
+    ["assets/*", "/var/lib/example", "644"],
+    ["target/release/assets/*", "/var/lib/example", "644"],
+    ["4.txt", "/var/lib/example/4.txt", "644"],
 ]
 
 [features]


### PR DESCRIPTION
As reported here: https://github.com/nickbabcock/dness/pull/278
installing a package with relative paths will fail on ubuntu 21.04 with
the following error message

```
dpkg: error processing archive latest.deb (--install):
 conffile name 'etc/dness/dness.conf' is not an absolute pathname
```

This appears to be a relative recent change to dpkg:
https://www.mail-archive.com/debian-dpkg-cvs@lists.debian.org/msg07446.html

This commit changes all references that are relative paths to absolute
paths which allows the built package to be installable on 21.04