### PR TITLE
Rewrite conffiles to ensure absolute paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/cargo-deb", "/usr/bin/", "755"],
-    ["README.md", "/usr/share/doc/cargo-deb/README", "644"],
+    ["target/release/cargo-deb", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/cargo-deb/README", "644"],
 ]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/cargo-deb", "/usr/bin/", "755"],
-    ["README.md", "/usr/share/doc/cargo-deb/README", "644"],
+    ["target/release/cargo-deb", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/cargo-deb/README", "644"],
 ]
 ```
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -16,11 +16,11 @@ section = "utils"
 priority = "optional"
 assets = [
     # binary
-    ["target/release/example", "/usr/bin/", "755"],
+    ["target/release/example", "usr/bin/", "755"],
     # assets
-    ["assets/*", "/var/lib/example", "644"],
-    ["target/release/assets/*", "/var/lib/example", "644"],
-    ["3.txt", "/var/lib/example/3.txt", "644"],
+    ["assets/*", "var/lib/example", "644"],
+    ["target/release/assets/*", "var/lib/example", "644"],
+    ["3.txt", "var/lib/example/3.txt", "644"],
 ]
 changelog = "changelog"
 default-features = false
@@ -29,11 +29,11 @@ features = ["example_debian_build"]
 [package.metadata.deb.variants.debug]
 assets =  [
     # binary
-    ["target/release/example", "/usr/bin/", "755"],
+    ["target/release/example", "usr/bin/", "755"],
     # assets
-    ["assets/*", "/var/lib/example", "644"],
-    ["target/release/assets/*", "/var/lib/example", "644"],
-    ["4.txt", "/var/lib/example/4.txt", "644"],
+    ["assets/*", "var/lib/example", "644"],
+    ["target/release/assets/*", "var/lib/example", "644"],
+    ["4.txt", "var/lib/example/4.txt", "644"],
 ]
 
 [features]


### PR DESCRIPTION
The man page for [deb-conffiles](https://man7.org/linux/man-pages/man5/deb-conffiles.5.html) states that conffiles should be absolute pathnames.

[Starting with dpkg 1.20.1](https://github.com/guillemj/dpkg/blob/68ab722604217d3ab836276acfc0ae1260b28f5f/debian/changelog#L393), dpkg will fail to install packages that don't use absolute pathnames for conffiles. Ubuntu 21.04 is a distro that is effected by this change.

This PR now ensures that conffile entries are absolute paths and rewrites them if they are not.

This PR also reverts #171. While using absolute paths for assets doesn't seem to affect behavior, as the default behavior of `tar` is to strip the leading slash (unless given `-P/--absolute-names`), it is more correct to use relative paths for asset paths as relative paths are shown in the debian handbook: https://debian-handbook.info/browse/stable/packaging-system.html

Tested that relative conffiles are rewritten as absolute and that the package is installable on Ubuntu 21.04

Closes #172