### PR TITLE
Allow changing the deb package name separator

### DIFF
--- a/src/debarchive.rs
+++ b/src/debarchive.rs
@@ -6,6 +6,8 @@ use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
+const DEFAULT_SEPARATOR: char = '_';
+
 pub struct DebArchive {
     out_abspath: PathBuf,
     prefix: PathBuf,
@@ -14,7 +16,9 @@ pub struct DebArchive {
 
 impl DebArchive {
     pub fn new(config: &Config) -> CDResult<Self> {
-        let out_filename = format!("{}_{}_{}.deb", config.deb_name, config.deb_version, config.architecture);
+        let out_filename = format!("{}{sep}{}{sep}{}.deb", config.deb_name, config.deb_version, config.architecture,
+            sep = config.deb_name_separator.unwrap_or(DEFAULT_SEPARATOR)
+        );
         let prefix = config.deb_temp_dir();
         let out_abspath = config.deb_output_path(&out_filename);
         {
@@ -31,7 +35,9 @@ impl DebArchive {
     }
 
     pub(crate) fn filename_glob(config: &Config) -> String {
-        format!("{}_*_{}.deb", config.deb_name, config.architecture)
+        format!("{}{sep}*{sep}{}.deb", config.deb_name, config.architecture,
+            sep = config.deb_name_separator.unwrap_or(DEFAULT_SEPARATOR)
+        )
     }
 
     pub fn add_path(&mut self, path: &Path) -> CDResult<()> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -275,6 +275,8 @@ pub struct Config {
     pub deb_name: String,
     /// The version to give the Debian package; usually the same as the Cargo version
     pub deb_version: String,
+    /// The character to use to separate the tokens in the deb package name. Default is '_'.
+    pub deb_name_separator: Option<char>,
     /// The software license of the project (SPDX format).
     pub license: Option<String>,
     /// The location of the license file
@@ -679,6 +681,7 @@ impl Cargo {
             name: self.package.name.clone(),
             deb_name: deb.name.take().unwrap_or_else(|| self.package.name.clone()),
             deb_version: deb_version.unwrap_or(self.version_string(deb.revision)),
+            deb_name_separator: deb.separator.take(),
             license: self.package.license.take(),
             license_file,
             license_file_skip_lines,
@@ -888,6 +891,7 @@ struct CargoDeb {
     pub license_file: Option<Vec<String>>,
     pub changelog: Option<String>,
     pub depends: Option<String>,
+    pub separator: Option<char>,
     pub recommends: Option<String>,
     pub conflicts: Option<String>,
     pub breaks: Option<String>,
@@ -919,6 +923,7 @@ impl CargoDeb {
             license_file: self.license_file.or(parent.license_file),
             changelog: self.changelog.or(parent.changelog),
             depends: self.depends.or(parent.depends),
+            separator: self.separator.or(parent.separator),
             recommends: self.recommends.or(parent.recommends),
             conflicts: self.conflicts.or(parent.conflicts),
             breaks: self.breaks.or(parent.breaks),


### PR DESCRIPTION
Hello and thank you very much for this crate!

I had a need to change the separator of the generated `deb` file. This PR was what I came up with. Please LMK if you'd like any updates or changes. 

Using it looks like:

```toml
[package.metadata.deb]
name = "some-package"
separator = '-'
```