### PR TITLE
Add optional support for Pre-Depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Everything is optional:
 - **copyright**: To whom and when the copyright of the software is granted. If not present, the list of authors is used.
 - **license-file**: 2-element array with a location of the license file and the amount of lines to skip at the top. If not present, package-level `license-file` is used.
 - **depends**: The runtime [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. Generated automatically when absent, or if the list includes the `$auto` keyword.
+- **pre-depends**: The [pre-dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. This will be empty by default.
 - **recommends**: The recommended [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. This will be empty by default.
 - **conflicts**, **breaks**, **replaces**, **provides** — [package transition](https://wiki.debian.org/PackageTransition) control.
 - **extended-description**: An extended description of the project — the more detailed the better. Either **extended-description-file** (see below) or package's `readme` file is used if it is not provided.

--- a/src/control.rs
+++ b/src/control.rs
@@ -154,6 +154,14 @@ fn generate_control(archive: &mut Archive, options: &Config, listener: &mut dyn 
         writeln!(&mut control, "Depends: {}", deps)?;
     }
 
+    if let Some(ref pre_depends) = options.pre_depends {
+        let pre_depends_normalized = pre_depends.trim();
+
+        if !pre_depends_normalized.is_empty() {
+            writeln!(&mut control, "Pre-Depends: {}", pre_depends_normalized)?;
+        }
+    }
+
     if let Some(ref recommends) = options.recommends {
         let recommends_normalized = recommends.trim();
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -300,6 +300,8 @@ pub struct Config {
     pub maintainer: String,
     /// The Debian dependencies required to run the project.
     pub depends: String,
+    /// The Debian pre-dependencies.
+    pub pre_depends: Option<String>,
     /// The Debian recommended dependencies.
     pub recommends: Option<String>,
     /// The Debian software category to which the package belongs.
@@ -700,6 +702,7 @@ impl Cargo {
                     .ok_or("The package must have a maintainer or authors property")?.to_owned())
             })?,
             depends: deb.depends.take().unwrap_or_else(|| "$auto".to_owned()),
+            pre_depends: deb.pre_depends.take(),
             recommends: deb.recommends.take(),
             conflicts: deb.conflicts.take(),
             breaks: deb.breaks.take(),
@@ -888,6 +891,7 @@ struct CargoDeb {
     pub license_file: Option<Vec<String>>,
     pub changelog: Option<String>,
     pub depends: Option<String>,
+    pub pre_depends: Option<String>,
     pub recommends: Option<String>,
     pub conflicts: Option<String>,
     pub breaks: Option<String>,
@@ -919,6 +923,7 @@ impl CargoDeb {
             license_file: self.license_file.or(parent.license_file),
             changelog: self.changelog.or(parent.changelog),
             depends: self.depends.or(parent.depends),
+            pre_depends: self.pre_depends.or(parent.pre_depends),
             recommends: self.recommends.or(parent.recommends),
             conflicts: self.conflicts.or(parent.conflicts),
             breaks: self.breaks.or(parent.breaks),


### PR DESCRIPTION
This commit adds optional support for a `Pre-Depends` field.
This is required for example when your package uses `debconf` in a `preinst` script,
where you need to pre-depend on `debconf` as described in [The Debconf Programmer's Tutorial](http://www.fifi.org/doc/debconf-doc/tutorial.html).
Also gets rid of another lintian warning:
>W: mypackage: missing-debconf-dependency-for-preinst