### PR TITLE
Add support for suggests and enhances dependency fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Everything is optional:
 - **depends**: The runtime [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. Generated automatically when absent, or if the list includes the `$auto` keyword.
 - **pre-depends**: The [pre-dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. This will be empty by default.
 - **recommends**: The recommended [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. This will be empty by default.
+- **suggests**: The suggested [dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html) of the project. This will be empty by default.
+- **enhances**: A list of packages this package can enhance. This will be empty by default.
 - **conflicts**, **breaks**, **replaces**, **provides** — [package transition](https://wiki.debian.org/PackageTransition) control.
 - **extended-description**: An extended description of the project — the more detailed the better. Either **extended-description-file** (see below) or package's `readme` file is used if it is not provided.
 - **extended-description-file**: A file with extended description of the project. When specified, used if **extended-description** is not provided.

--- a/src/control.rs
+++ b/src/control.rs
@@ -175,6 +175,22 @@ fn generate_control(archive: &mut Archive, options: &Config, listener: &mut dyn 
         }
     }
 
+    if let Some(ref suggests) = options.suggests {
+        let suggests_normalized = suggests.trim();
+
+        if !suggests_normalized.is_empty() {
+            writeln!(&mut control, "Suggests: {}", suggests_normalized)?;
+        }
+    }
+
+    if let Some(ref enhances) = options.enhances {
+        let enhances_normalized = enhances.trim();
+
+        if !enhances_normalized.is_empty() {
+            writeln!(&mut control, "Enhances: {}", enhances_normalized)?;
+        }
+    }
+
     if let Some(ref conflicts) = options.conflicts {
         writeln!(&mut control, "Conflicts: {}", conflicts)?;
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -304,6 +304,10 @@ pub struct Config {
     pub pre_depends: Option<String>,
     /// The Debian recommended dependencies.
     pub recommends: Option<String>,
+    /// The Debian suggested dependencies.
+    pub suggests: Option<String>,
+    /// The list of packages this package can enhance.
+    pub enhances: Option<String>,
     /// The Debian software category to which the package belongs.
     pub section: Option<String>,
     /// The Debian priority of the project. Typically 'optional'.
@@ -704,6 +708,8 @@ impl Cargo {
             depends: deb.depends.take().unwrap_or_else(|| "$auto".to_owned()),
             pre_depends: deb.pre_depends.take(),
             recommends: deb.recommends.take(),
+            suggests: deb.suggests.take(),
+            enhances: deb.enhances.take(),
             conflicts: deb.conflicts.take(),
             breaks: deb.breaks.take(),
             replaces: deb.replaces.take(),
@@ -906,6 +912,8 @@ struct CargoDeb {
     pub depends: Option<String>,
     pub pre_depends: Option<String>,
     pub recommends: Option<String>,
+    pub suggests: Option<String>,
+    pub enhances: Option<String>,
     pub conflicts: Option<String>,
     pub breaks: Option<String>,
     pub replaces: Option<String>,
@@ -938,6 +946,8 @@ impl CargoDeb {
             depends: self.depends.or(parent.depends),
             pre_depends: self.pre_depends.or(parent.pre_depends),
             recommends: self.recommends.or(parent.recommends),
+            suggests: self.suggests.or(parent.suggests),
+            enhances: self.enhances.or(parent.enhances),
             conflicts: self.conflicts.or(parent.conflicts),
             breaks: self.breaks.or(parent.breaks),
             replaces: self.replaces.or(parent.replaces),


### PR DESCRIPTION
This adds support for "suggests" (like recommends but not so strong recommendation) and "enhances" (which packages does this package enhance) fields for the control file. Also, I think this can close #159 and close #163.