### PR TITLE
Appended application with --no_release argument.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-deb"
-version = "1.31.0"
+version = "1.32.0"
 dependencies = [
  "ar",
  "cargo_toml",

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ struct CliOptions {
     manifest_path: Option<String>,
     cargo_build_flags: Vec<String>,
     deb_version: Option<String>,
+    no_release: bool,
 }
 
 fn main() {
@@ -40,6 +41,8 @@ fn main() {
     cli_opts.optflag("h", "help", "Print this help menu");
     cli_opts.optflag("", "version", "Show the version of cargo-deb");
     cli_opts.optopt("", "deb-version", "Alternate version string for package", "version");
+    cli_opts.optflag("", "no-release", "Used in combination with 'no-build'. Assumes a none release build profile.");
+
 
     let matches = match cli_opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -73,6 +76,7 @@ fn main() {
         package_name: matches.opt_str("package"),
         manifest_path: matches.opt_str("manifest-path"),
         deb_version: matches.opt_str("deb-version"),
+        no_release: matches.opt_present("no-release"),
         cargo_build_flags: matches.free,
     }) {
         Ok(()) => {},
@@ -114,6 +118,7 @@ fn process(
         verbose,
         mut cargo_build_flags,
         deb_version,
+        no_release,
     }: CliOptions,
 ) -> CDResult<()> {
     let target = target.as_deref();
@@ -148,6 +153,7 @@ fn process(
         variant,
         deb_version,
         listener,
+        no_release,
     )?;
     reset_deb_temp_directory(&options)?;
 


### PR DESCRIPTION
--no-build assumes that a package is build in release mode. added a flag that will load binaries/libs from the debug path.

You could explicit set the debug path in the "assets" option to work-around cargo-deb looking in the wrong folder. However this doesnt scale nice, if you have a lot of different compile targets. You would have to create a variant for each output target.
Instead, pass a flag, --no-release, to look in the /target/debug output-dir.

Chose this solution over an fallback solution. e.g. when files dont exist in
the target/release folder, try target/debug