### PR TITLE
Resolve dependencies with dpkg-shlibdeps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rayon = "1.5.1"
 regex = { version = "1.5.4", default-features = false, features = ["std"] }
 itertools = "0.10.1"
 num_cpus = { version = "1.13.0", optional = true }
+tempdir = "0.3.7"
 
 [features]
 default = ["lzma"]
@@ -71,7 +72,6 @@ opt-level = 3
 debug = false
 
 [dev-dependencies]
-tempdir = "0.3.7"
 mockall = "0.10.2"
 rstest = "0.11.0"
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a [Cargo](https://doc.rust-lang.org/cargo/) helper command which automat
 cargo install cargo-deb
 ```
 
-Requires Rust 1.42+, and optionally `dpkg`, `ldd` and `liblzma-dev`. Compatible with Ubuntu.
+Requires Rust 1.42+, and optionally `dpkg`, `dpkg-dev` and `liblzma-dev`. Compatible with Ubuntu.
 
 ## Usage
 

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,136 +1,62 @@
 use crate::error::*;
-use crate::listener::Listener;
-use rayon::prelude::*;
-use std::collections::HashSet;
+use std::io::BufRead;
 use std::path::Path;
 use std::process::Command;
+use tempdir::TempDir;
 
-/// Resolves the dependencies based on the output of ldd on the binary.
-pub fn resolve(path: &Path, architecture: &str, listener: &dyn Listener) -> CDResult<Vec<String>> {
-    let dependencies = {
-        let output = Command::new("ldd")
-            .arg(path)
-            .output()
-            .map_err(|e| CargoDebError::CommandFailed(e, "ldd"))?;
-        if !output.status.success() {
-            return Err(CargoDebError::CommandError("ldd", path.display().to_string(), output.stderr));
-        }
-        String::from_utf8(output.stdout).expect("utf8")
-    };
+/// Resolves the dependencies based on the output of dpkg-shlibdeps on the binary.
+pub fn resolve(path: &Path) -> CDResult<Vec<String>> {
+    let temp_folder = TempDir::new("cargo-deb-dependency-resolve")?;
+    let debian_folder = temp_folder.path().join("debian");
+    let control_file_path = debian_folder.join("control");
+    std::fs::create_dir_all(&debian_folder)?;
 
-    // Create an iterator of unique dependencies
-    let dependencies: HashSet<_> = dependencies.lines()
-        // The syntax is "name => path (addr)"
-        .filter_map(|line| {
-            let mut parts = line.splitn(2, "=>");
-            let name = parts.next()?.trim();
+    {
+        // dpkg-shlibdeps requires a (possibly empty) debian/control file to exist in its working
+        // directory. The executable location doesn't matter.
+        let _file = std::fs::File::create(&control_file_path)?;
+    }
 
-            if name == "libgcc_s.so.1" {
-                // it's guaranteed by LSB to always be present
-                return None;
+    const DPKG_SHLIBDEPS_COMMAND: &str = "dpkg-shlibdeps";
+    let output = Command::new(DPKG_SHLIBDEPS_COMMAND)
+        .arg("-O") // Print result to stdout instead of a file.
+        .arg(path)
+        .current_dir(temp_folder.path())
+        .output()
+        .map_err(|e| CargoDebError::CommandFailed(e, DPKG_SHLIBDEPS_COMMAND))?;
+    if !output.status.success() {
+        return Err(CargoDebError::CommandError(
+            DPKG_SHLIBDEPS_COMMAND,
+            path.display().to_string(),
+            output.stderr,
+        ));
+    }
+
+    let deps = output
+        .stdout
+        .lines()
+        .find(|line_result| {
+            if let Ok(line) = line_result {
+                line.starts_with("shlibs:")
+            } else {
+                false
             }
-            parts.next()?.split_whitespace().next()
         })
-        // If the field exists and starts with '/', we have found a filepath.
-        .filter(|x| x.starts_with('/'))
-        // Obtain the names of the packages.
-        .filter_map(|path_str| {
-            get_package_name_with_fallback(path_str)
-                .map_err(|err| {
-                    listener.warning(format!("{} (skip this auto dep for {})", err, path.display()));
-                    err
-                })
-                .ok()
-        })
-        // only collect unique packages.
+        .ok_or(CargoDebError::Str("Failed to find dependency specification."))??
+        .replace("shlibs:Depends=", "")
+        .split(',')
+        .map(|dep| dep.trim().to_string())
+        .filter(|dep| !dep.starts_with("libgcc-")) // libgcc guaranteed by LSB to always be present
         .collect();
 
-    Ok(dependencies.into_par_iter().map(|package| {
-        // There can be multiple arch-specific versions of a package
-        let arch_version = format!("{}:{}", package, architecture);
-        match get_version(&arch_version) {
-            Ok(version) => {
-                format!("{} (>= {})", package, version)
-            },
-            Err(e) => {
-                listener.warning(format!("Can't get version of {}: {}", arch_version, e));
-                package
-            },
-        }
-    }).collect())
-}
-
-/// Debian's libssl links with a lib that isn't "installed", #26
-/// but exists in /usr/lib instead of /lib
-fn get_package_name_with_fallback(path: &str) -> CDResult<String> {
-    match get_package_name(path) {
-        Ok(res) => Ok(res),
-        Err(e @ CargoDebError::PackageNotFound(..)) => {
-            let usr_path = format!("/usr{}", path);
-            match get_package_name(&usr_path) {
-                Ok(res) => Ok(res),
-                _ => Err(e),
-            }
-        },
-        Err(e) => Err(e),
-    }
-}
-
-/// Obtains the name of the package that belongs to the file that ldd returned.
-fn get_package_name(path: &str) -> CDResult<String> {
-    let output = Command::new("dpkg").arg("-S").arg(path)
-        .output().map_err(|e| CargoDebError::CommandFailed(e, "dpkg -S"))?;
-    if output.status.success() {
-        if let Some(name) = parse_dpkg_search(&output.stdout) {
-            return Ok(name);
-        }
-    }
-    Err(CargoDebError::PackageNotFound(path.to_owned(), output.stderr))
-}
-
-fn parse_dpkg_search(output: &[u8]) -> Option<String> {
-    let output = String::from_utf8_lossy(output);
-    for line in output.lines() {
-        if line.starts_with("diversion ") || !line.contains(':') {
-            continue;
-        }
-        let mut parts = line.splitn(2, ':');
-        if let Some(name) = parts.next() {
-            return Some(name.to_owned());
-        }
-    }
-    None
-}
-
-/// Uses apt-cache policy to determine the version of the package that this project was built against.
-fn get_version(package: &str) -> CDResult<String> {
-    let output = Command::new("dpkg-query")
-        .arg("--showformat=${Version}")
-        .arg("--show")
-        .arg(package)
-        .output()
-        .map_err(|e| CargoDebError::CommandFailed(e, "dpkg-query (get package version)"))?;
-    if !output.status.success() {
-        return Err(CargoDebError::CommandError("dpkg-query (get package version)", package.to_owned(), output.stderr));
-    }
-    let version = ::std::str::from_utf8(&output.stdout).expect("utf8");
-    Ok(version.splitn(2, '-').next().unwrap().to_owned())
+    Ok(deps)
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn resolve_test() {
     let exe = std::env::current_exe().unwrap();
-    let arch = crate::manifest::get_arch(crate::DEFAULT_TARGET);
-    let deps = resolve(&exe, arch, &crate::listener::NoOpListener).unwrap();
+    let deps = resolve(&exe).unwrap();
     assert!(deps.iter().any(|d| d.starts_with("libc")));
     assert!(!deps.iter().any(|d| d.starts_with("libgcc")));
-}
-
-#[test]
-fn parse_search() {
-    assert_eq!("libgl1-mesa-glx", parse_dpkg_search(b"diversion by glx-diversions from: /usr/lib/x86_64-linux-gnu/libGL.so.1
-diversion by glx-diversions to: /usr/lib/mesa-diverted/x86_64-linux-gnu/libGL.so.1
-libgl1-mesa-glx:amd64: /usr/lib/x86_64-linux-gnu/libGL.so.1
-").unwrap());
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -394,7 +394,7 @@ impl Config {
                 let bin = self.all_binaries();
                 let resolved = bin.par_iter()
                     .filter_map(|p| p.path())
-                    .filter_map(|bname| match resolve(bname, &self.architecture, listener) {
+                    .filter_map(|bname| match resolve(bname) {
                         Ok(bindeps) => Some(bindeps),
                         Err(err) => {
                             listener.warning(format!("{} (no auto deps for {})", err, bname.display()));


### PR DESCRIPTION
This replaces the dependency resolving from `ldd` to use `dpkg-shlibdeps` instead, as suggested in #170 and #178.

As an example of this change, the old `ldd`-based dependencies were resolved as:
```
 Depends: libkrb5-3 (>= 1.17), libc6 (>= 2.31), libkeyutils1 (>= 1.6), libnorm1 (>= 1.5.8+dfsg2), libgssapi-krb5-2 (>= 1.17), libpgm-5.2-0 (>= 5.2.122~dfsg), libkrb5support0 (>= 1.17), libstdc++6 (>= 10.3.0), libzmq5 (>= 4.3.2), libsodium23 (>= 1.0.18), libcom-err2 (>= 1.45.5), libk5crypto3 (>= 1.17)
```

While the new approach resolves this to simply:
```
Depends: libc6 (>= 2.18), libzmq5 (>= 4.0.1+dfsg)
```

Some notes:
- As noted by @H-M-H in #170, `dpkg-shlibdeps` requires the existance of a `debian/control` file which can even be empty. Furthermore, it's seemingly not even necessary that the executable is anywhere near the control file.